### PR TITLE
Implement goal_glide CLI and basic tests

### DIFF
--- a/goal_glide/__main__.py
+++ b/goal_glide/__main__.py
@@ -1,0 +1,4 @@
+from .cli import cli
+
+if __name__ == '__main__':
+    cli()

--- a/goal_glide/cli.py
+++ b/goal_glide/cli.py
@@ -1,0 +1,60 @@
+import uuid
+from datetime import datetime
+import click
+from rich.console import Console
+from rich.table import Table
+from .models import Goal
+from .storage import Storage
+
+console = Console()
+
+@click.group()
+@click.pass_context
+def cli(ctx):
+    ctx.obj = Storage()
+
+@cli.command()
+@click.argument('title')
+@click.option('-p', '--priority', type=click.Choice(['low', 'med', 'high']), default='med')
+@click.pass_obj
+def add(storage: Storage, title: str, priority: str):
+    title = title.strip()
+    if not title:
+        console.print('[red]Title cannot be empty.[/red]')
+        return
+    if storage.find_by_title(title):
+        console.print('[yellow]Warning: goal with this title already exists.[/yellow]')
+    goal = Goal(id=str(uuid.uuid4()), title=title, created=datetime.utcnow(), priority=priority)
+    storage.add_goal(goal)
+    console.print(f"[green]Added:[/green] {title} ({goal.id})")
+
+@cli.command()
+@click.option('--all', 'show_all', is_flag=True, help='Show all goals including archived')
+@click.option('--archived', 'archived_only', is_flag=True, help='Show only archived')
+@click.option('--priority', type=click.Choice(['low', 'med', 'high']))
+@click.pass_obj
+def list(storage: Storage, show_all: bool, archived_only: bool, priority: str):
+    goals = storage.list_goals(include_archived=show_all, archived_only=archived_only, priority=priority)
+    table = Table(title='Goals')
+    table.add_column('ID')
+    table.add_column('Title')
+    table.add_column('Priority')
+    table.add_column('Created')
+    table.add_column('Archived')
+    for g in goals:
+        table.add_row(g.id.split('-')[0], g.title, g.priority, g.created.isoformat(), str(g.archived))
+    console.print(table)
+
+@cli.command()
+@click.argument('goal_id')
+@click.pass_obj
+def remove(storage: Storage, goal_id: str):
+    if click.confirm(f'Remove goal {goal_id}?'):
+        removed = storage.remove_goal(goal_id)
+        if removed:
+            console.print(f"[green]Removed[/green] {goal_id}")
+        else:
+            console.print('[red]Goal not found.[/red]')
+
+if __name__ == '__main__':
+    cli()

--- a/goal_glide/models.py
+++ b/goal_glide/models.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+
+@dataclass
+class Goal:
+    id: str
+    title: str
+    created: datetime
+    priority: str = 'medium'
+    archived: bool = False

--- a/goal_glide/storage.py
+++ b/goal_glide/storage.py
@@ -1,0 +1,41 @@
+import os
+from pathlib import Path
+from typing import Iterable, Optional
+from tinydb import TinyDB, Query
+from .models import Goal
+
+DB_NAME = 'goal_glide.json'
+TABLE_NAME = 'goals'
+
+class Storage:
+    def __init__(self, path: Optional[Path] = None):
+        env_path = os.environ.get('GOAL_GLIDE_DB')
+        self.path = Path(path or env_path or DB_NAME)
+        self.db = TinyDB(self.path)
+        self.table = self.db.table(TABLE_NAME)
+
+    def add_goal(self, goal: Goal) -> None:
+        self.table.insert(goal.__dict__)
+
+    def list_goals(self, *, include_archived: bool = False, archived_only: bool = False,
+                   priority: Optional[str] = None) -> Iterable[Goal]:
+        q = Query()
+        if archived_only:
+            cond = q.archived == True
+        elif include_archived:
+            cond = (q.archived == True) | (q.archived == False)
+        else:
+            cond = q.archived == False
+        results = self.table.search(cond)
+        if priority:
+            results = [r for r in results if r['priority'] == priority]
+        return [Goal(**r) for r in results]
+
+    def remove_goal(self, goal_id: str) -> bool:
+        q = Query()
+        return bool(self.table.remove(q.id == goal_id))
+
+    def find_by_title(self, title: str) -> Optional[Goal]:
+        q = Query()
+        r = self.table.get(q.title == title)
+        return Goal(**r) if r else None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+click
+rich
+tinydb
+pytest

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,23 @@
+from click.testing import CliRunner
+from goal_glide.cli import cli
+from goal_glide.storage import DB_NAME
+
+
+def test_add_list_remove(tmp_path):
+    db_path = tmp_path / DB_NAME
+    runner = CliRunner()
+
+    # add goal
+    result = runner.invoke(cli, ['add', 'Test Goal'], env={'GOAL_GLIDE_DB': str(db_path)})
+    assert result.exit_code == 0
+
+    # list
+    result = runner.invoke(cli, ['list'], env={'GOAL_GLIDE_DB': str(db_path)})
+    assert 'Test Goal' in result.output
+
+    # remove
+    # get id from list output
+    lines = [l for l in result.output.splitlines() if 'Test Goal' in l]
+    goal_id = lines[0].split()[0]
+    result = runner.invoke(cli, ['remove', goal_id], input='y\n', env={'GOAL_GLIDE_DB': str(db_path)})
+    assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- add requirements.txt with CLI and DB deps
- implement dataclass Goal model
- implement JSON TinyDB storage layer
- build Click CLI with add/list/remove commands
- add basic test for CLI operations

## Testing
- `pip install -q -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_68426acbbab0832291768f8d6e20c681