### PR TITLE
fix: implement missing storage methods and alias CLI

### DIFF
--- a/goal_glide/cli.py
+++ b/goal_glide/cli.py
@@ -1,20 +1,21 @@
 from __future__ import annotations
 
-import uuid
-from pathlib import Path
-from datetime import datetime
 import os
+import uuid
+from datetime import datetime
+from pathlib import Path
 
 import click
+
 from rich.console import Console
 
-from .models.goal import Goal, Priority
-from .models.storage import Storage
 from .exceptions import (
     GoalAlreadyArchivedError,
     GoalNotArchivedError,
     GoalNotFoundError,
 )
+from .models.goal import Goal, Priority
+from .models.storage import Storage
 from .services.render import render_goals
 
 
@@ -129,5 +130,8 @@ def list_goals(archived: bool, show_all: bool, priority: str | None) -> None:
     console.print(table)
 
 
+cli = goal
+
+
 if __name__ == "__main__":
-    goal()
+    cli()

--- a/goal_glide/models/storage.py
+++ b/goal_glide/models/storage.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 
-from tinydb import TinyDB, Query
+from tinydb import Query, TinyDB
 
-from .goal import Goal, Priority
 from ..exceptions import (
     GoalAlreadyArchivedError,
     GoalNotArchivedError,
     GoalNotFoundError,
 )
+from .goal import Goal, Priority
 
 
 class Storage:
@@ -99,3 +99,12 @@ class Storage:
                 continue
             results.append(g)
         return results
+
+    def remove_goal(self, goal_id: str) -> None:
+        if not self.table.contains(Query().id == goal_id):
+            raise GoalNotFoundError(f"Goal {goal_id} not found")
+        self.table.remove(Query().id == goal_id)
+
+    def find_by_title(self, title: str) -> Goal | None:
+        row = self.table.get(Query().title == title)
+        return self._row_to_goal(row) if row else None

--- a/goal_glide/storage.py
+++ b/goal_glide/storage.py
@@ -1,34 +1,41 @@
 import os
 from pathlib import Path
 from typing import Iterable, Optional
-from tinydb import TinyDB, Query
-from .models import Goal
 
-DB_NAME = 'goal_glide.json'
-TABLE_NAME = 'goals'
+from tinydb import Query, Table, TinyDB
+
+from .models.goal import Goal
+
+DB_NAME = "goal_glide.json"
+TABLE_NAME = "goals"
+
 
 class Storage:
     def __init__(self, path: Optional[Path] = None):
-        env_path = os.environ.get('GOAL_GLIDE_DB')
+        env_path = os.environ.get("GOAL_GLIDE_DB")
         self.path = Path(path or env_path or DB_NAME)
-        self.db = TinyDB(self.path)
-        self.table = self.db.table(TABLE_NAME)
+        self.db: TinyDB = TinyDB(self.path)
+        self.table: Table = self.db.table(TABLE_NAME)
 
     def add_goal(self, goal: Goal) -> None:
         self.table.insert(goal.__dict__)
 
-    def list_goals(self, *, include_archived: bool = False, archived_only: bool = False,
-                   priority: Optional[str] = None) -> Iterable[Goal]:
+    def list_goals(
+        self,
+        *,
+        include_archived: bool = False,
+        archived_only: bool = False,
+        priority: Optional[str] = None,
+    ) -> Iterable[Goal]:
         q = Query()
         if archived_only:
-            cond = q.archived == True
+            results = self.table.search(q.archived == True)  # noqa: E712
         elif include_archived:
-            cond = (q.archived == True) | (q.archived == False)
+            results = self.table.all()
         else:
-            cond = q.archived == False
-        results = self.table.search(cond)
+            results = self.table.search(q.archived == False)  # noqa: E712
         if priority:
-            results = [r for r in results if r['priority'] == priority]
+            results = [r for r in results if r["priority"] == priority]
         return [Goal(**r) for r in results]
 
     def remove_goal(self, goal_id: str) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 from click.testing import CliRunner
+
 from goal_glide.cli import cli
 from goal_glide.storage import DB_NAME
 
@@ -8,16 +9,20 @@ def test_add_list_remove(tmp_path):
     runner = CliRunner()
 
     # add goal
-    result = runner.invoke(cli, ['add', 'Test Goal'], env={'GOAL_GLIDE_DB': str(db_path)})
+    result = runner.invoke(
+        cli, ["add", "Test Goal"], env={"GOAL_GLIDE_DB": str(db_path)}
+    )
     assert result.exit_code == 0
 
     # list
-    result = runner.invoke(cli, ['list'], env={'GOAL_GLIDE_DB': str(db_path)})
-    assert 'Test Goal' in result.output
+    result = runner.invoke(cli, ["list"], env={"GOAL_GLIDE_DB": str(db_path)})
+    assert "Test Goal" in result.output
 
     # remove
     # get id from list output
-    lines = [l for l in result.output.splitlines() if 'Test Goal' in l]
+    lines = [line for line in result.output.splitlines() if "Test Goal" in line]
     goal_id = lines[0].split()[0]
-    result = runner.invoke(cli, ['remove', goal_id], input='y\n', env={'GOAL_GLIDE_DB': str(db_path)})
+    result = runner.invoke(
+        cli, ["remove", goal_id], input="y\n", env={"GOAL_GLIDE_DB": str(db_path)}
+    )
     assert result.exit_code == 0

--- a/tinydb/__init__.py
+++ b/tinydb/__init__.py
@@ -46,6 +46,18 @@ class Table:
     def contains(self, predicate: Callable[[dict[str, Any]], bool]) -> bool:
         return self.get(predicate) is not None
 
+    def search(
+        self, predicate: Callable[[dict[str, Any]], bool]
+    ) -> list[dict[str, Any]]:
+        return [row for row in self.db.data.get(self.name, []) if predicate(row)]
+
+    def remove(self, predicate: Callable[[dict[str, Any]], bool]) -> int:
+        rows = self.db.data.get(self.name, [])
+        before = len(rows)
+        self.db.data[self.name] = [row for row in rows if not predicate(row)]
+        self.db._save()
+        return before - len(self.db.data[self.name])
+
     def update(
         self, record: dict[str, Any], predicate: Callable[[dict[str, Any]], bool]
     ) -> None:


### PR DESCRIPTION
## Summary
- export CLI as `cli` for test access
- implement `remove_goal` and `find_by_title`
- update storage module to avoid mypy/ruff errors
- provide minimal `tinydb` search/remove helpers
- fix variable name in tests

## Testing
- `ruff check --fix .`
- `black goal_glide/cli.py goal_glide/models/storage.py goal_glide/storage.py tests/test_cli.py tinydb/__init__.py`
- `isort goal_glide/cli.py goal_glide/models/storage.py goal_glide/storage.py tests/test_cli.py tinydb/__init__.py`
- `mypy goal_glide --strict`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68426f5c08488322a6b8c0db6b0a47bb