### PR TITLE
feat: tags & search (milestone 6)

### DIFF
--- a/goal_glide/exceptions.py
+++ b/goal_glide/exceptions.py
@@ -16,3 +16,7 @@ class EmptyThoughtError(ValueError):
 
 class GoalDoesNotExistError(ValueError):
     pass
+
+
+class InvalidTagError(ValueError):
+    pass

--- a/goal_glide/models/goal.py
+++ b/goal_glide/models/goal.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 
@@ -18,3 +18,4 @@ class Goal:
     created: datetime
     priority: Priority = Priority.medium
     archived: bool = False
+    tags: list[str] = field(default_factory=list)

--- a/goal_glide/services/render.py
+++ b/goal_glide/services/render.py
@@ -12,6 +12,7 @@ def render_goals(goals: list[Goal]) -> Table:
     table.add_column("Priority")
     table.add_column("Created")
     table.add_column("Archived")
+    table.add_column("Tags")
     for g in goals:
         table.add_row(
             g.id,
@@ -19,5 +20,6 @@ def render_goals(goals: list[Goal]) -> Table:
             g.priority.value,
             g.created.isoformat(timespec="seconds"),
             "yes" if g.archived else "",
+            ", ".join(g.tags),
         )
     return table

--- a/goal_glide/utils/tag.py
+++ b/goal_glide/utils/tag.py
@@ -1,0 +1,11 @@
+import re
+
+from ..exceptions import InvalidTagError
+
+_TAG_RE = re.compile(r"^[a-z0-9][a-z0-9-_]{0,29}$")
+
+
+def validate_tag(tag: str) -> str:
+    if not _TAG_RE.fullmatch(tag):
+        raise InvalidTagError(f"Invalid tag '{tag}'. Tags must match {_TAG_RE.pattern}")
+    return tag.lower()

--- a/tests/test_migration_tags.py
+++ b/tests/test_migration_tags.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+from goal_glide.models.storage import Storage
+from tinydb import TinyDB
+
+
+def test_migrate_adds_empty_tags(tmp_path: Path) -> None:
+    db_path = tmp_path / "db.json"
+    db = TinyDB(db_path)
+    goals = db.table("goals")
+    goals.insert({"id": "g1", "title": "t", "created": datetime.now().isoformat()})
+
+    storage = Storage(tmp_path)
+    goal = storage.get_goal("g1")
+    assert goal.tags == []

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from goal_glide.cli import goal
+from goal_glide.models.storage import Storage
+
+
+@pytest.fixture()
+def runner(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> CliRunner:
+    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
+    return CliRunner()
+
+
+def test_add_single_tag(tmp_path: Path, runner: CliRunner) -> None:
+    runner.invoke(goal, ["add", "g"])
+    gid = Storage(tmp_path).list_goals()[0].id
+    result = runner.invoke(goal, ["tag", "add", gid, "writing"])
+    assert result.exit_code == 0
+    assert "writing" in result.output
+    assert Storage(tmp_path).get_goal(gid).tags == ["writing"]
+
+
+def test_add_duplicate_tag_no_dupe(tmp_path: Path, runner: CliRunner) -> None:
+    runner.invoke(goal, ["add", "g"])
+    gid = Storage(tmp_path).list_goals()[0].id
+    runner.invoke(goal, ["tag", "add", gid, "health"])
+    result = runner.invoke(goal, ["tag", "add", gid, "health"])
+    assert result.exit_code == 0
+    assert Storage(tmp_path).get_goal(gid).tags == ["health"]
+
+
+def test_add_invalid_tag_fails(tmp_path: Path, runner: CliRunner) -> None:
+    runner.invoke(goal, ["add", "g"])
+    gid = Storage(tmp_path).list_goals()[0].id
+    result = runner.invoke(goal, ["tag", "add", gid, "BadTag!"])
+    assert result.exit_code != 0
+    assert not Storage(tmp_path).get_goal(gid).tags
+
+
+def test_remove_tag(tmp_path: Path, runner: CliRunner) -> None:
+    runner.invoke(goal, ["add", "g"])
+    gid = Storage(tmp_path).list_goals()[0].id
+    runner.invoke(goal, ["tag", "add", gid, "a", "b"])
+    result = runner.invoke(goal, ["tag", "rm", gid, "a"])
+    assert result.exit_code == 0
+    assert Storage(tmp_path).get_goal(gid).tags == ["b"]
+
+
+def test_remove_nonexistent_tag_warns(tmp_path: Path, runner: CliRunner) -> None:
+    runner.invoke(goal, ["add", "g"])
+    gid = Storage(tmp_path).list_goals()[0].id
+    result = runner.invoke(goal, ["tag", "rm", gid, "none"])
+    assert result.exit_code == 0
+    assert "not present" in result.output
+
+
+def test_list_filter_single_tag(tmp_path: Path, runner: CliRunner) -> None:
+    runner.invoke(goal, ["add", "g1"])
+    runner.invoke(goal, ["add", "g2"])
+    goals = Storage(tmp_path).list_goals()
+    runner.invoke(goal, ["tag", "add", goals[0].id, "work"])
+    runner.invoke(goal, ["tag", "add", goals[1].id, "play"])
+    result = runner.invoke(goal, ["list", "--tag", "work"])
+    assert "g1" in result.output and "g2" not in result.output
+
+
+def test_list_filter_multiple_tags_and_logic(tmp_path: Path, runner: CliRunner) -> None:
+    runner.invoke(goal, ["add", "g1"])
+    gid = Storage(tmp_path).list_goals()[0].id
+    runner.invoke(goal, ["tag", "add", gid, "a", "b"])
+    runner.invoke(goal, ["add", "g2"])
+    gid2 = Storage(tmp_path).list_goals()[1].id
+    runner.invoke(goal, ["tag", "add", gid2, "a"])
+    result = runner.invoke(goal, ["list", "--tag", "a", "--tag", "b"])
+    assert "g1" in result.output and "g2" not in result.output


### PR DESCRIPTION
## Summary
- add `tags` field to `Goal`
- support tag operations in storage and CLI
- validate tags with regex
- render tags column in goal listings
- migrate existing DB rows and add tests

## Testing
- `ruff check --fix .`
- `isort .`
- `black .`
- `mypy goal_glide --strict`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68427ed6b0ac8322a7b31cbee5c8d658