### PR TITLE
feat: first Textual TUI (milestone 8)

### DIFF
--- a/goal_glide/tui.css
+++ b/goal_glide/tui.css
@@ -1,0 +1,11 @@
+Screen {
+    layout: horizontal;
+}
+#goal_table {
+    width: 40%;
+    border: tall $surface;
+}
+#detail_panel {
+    width: 60%;
+    padding: 1 2;
+}

--- a/goal_glide/tui.py
+++ b/goal_glide/tui.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import uuid4
+
+# ensure real rich is used (textual dependency)
+if "" in sys.path:
+    sys.path.remove("")
+    sys.path.append("")
+
+from textual.app import App, ComposeResult
+from textual.coordinate import Coordinate
+from textual.reactive import reactive
+from textual.widgets import DataTable, Footer, Header, Static
+
+from .cli import get_storage
+from .models.goal import Goal, Priority
+from .models.session import PomodoroSession as ModelSession
+from .models.thought import Thought
+from .services import pomodoro
+
+
+@dataclass(slots=True)
+class RunningSession:
+    goal_id: str
+    start: datetime
+    duration_sec: int
+
+
+class GoalGlideApp(App[None]):
+    CSS_PATH = "tui.css"
+    BINDINGS = [
+        ("a", "add_goal", "Add Goal"),
+        ("delete", "archive_goal", "Archive"),
+        ("s", "toggle_pomo", "Start/Stop"),
+        ("t", "jot_thought", "Thought"),
+        ("q", "quit", "Quit"),
+    ]
+
+    active_session: reactive[RunningSession | None] = reactive(None)
+    selected_goal: reactive[str | None] = reactive(None)
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        yield DataTable(id="goal_table")
+        yield Static(id="detail_panel")
+        yield Footer()
+
+    async def on_mount(self) -> None:
+        self.storage = get_storage()
+        table = self.query_one(DataTable)
+        table.add_columns("ID", "Title", "Pri.", "Tags")
+        await self.refresh_goals()
+        self.set_interval(1.0, self._tick)
+        table.focus()
+
+    async def refresh_goals(self) -> None:
+        table = self.query_one(DataTable)
+        table.clear()
+        goals = list(self.storage.list_goals())
+        for g in goals:
+            table.add_row(g.id, g.title, g.priority.value, ", ".join(g.tags), key=g.id)
+        if goals:
+            table.cursor_type = "row"
+            table.cursor_coordinate = Coordinate(0, 0)
+
+    async def on_data_table_row_highlighted(
+        self, event: DataTable.RowHighlighted
+    ) -> None:
+        self.selected_goal = str(event.row_key)
+        self.update_detail()
+
+    def update_detail(self) -> None:
+        panel = self.query_one("#detail_panel", Static)
+        if not self.selected_goal:
+            panel.update("No goal selected")
+            return
+        goal = self.storage.get_goal(self.selected_goal)
+        lines = [f"[b]{goal.title}[/b]", f"Priority: {goal.priority.value}"]
+        if goal.tags:
+            lines.append(f"Tags: {', '.join(goal.tags)}")
+        if self.active_session and self.active_session.goal_id == goal.id:
+            elapsed = int((datetime.now() - self.active_session.start).total_seconds())
+            remaining = max(self.active_session.duration_sec - elapsed, 0)
+            bar_len = 20
+            filled = int(elapsed / self.active_session.duration_sec * bar_len)
+            bar = "#" * filled + "-" * (bar_len - filled)
+            mins, sec = divmod(remaining, 60)
+            lines.append(f"[{bar}] {mins:02}:{sec:02}")
+        else:
+            lines.append("Press S to start Pomodoro")
+        panel.update("\n".join(lines))
+
+    async def action_add_goal(self) -> None:  # pragma: no cover - interactive
+        title = input("Goal title: ").strip()
+        if not title:
+            return
+        g = Goal(
+            id=str(uuid4()),
+            title=title,
+            created=datetime.utcnow(),
+            priority=Priority.medium,
+        )
+        self.storage.add_goal(g)
+        await self.refresh_goals()
+
+    async def action_archive_goal(self) -> None:  # pragma: no cover - interactive
+        if not self.selected_goal:
+            return
+        self.storage.archive_goal(self.selected_goal)
+        await self.refresh_goals()
+
+    async def action_jot_thought(self) -> None:  # pragma: no cover - interactive
+        text = input("Thought: ").strip()
+        if not text:
+            return
+        thought = Thought.new(text, self.selected_goal)
+        self.storage.add_thought(thought)
+
+    async def action_toggle_pomo(self) -> None:
+        if not self.selected_goal:
+            return
+        if self.active_session and self.active_session.goal_id == self.selected_goal:
+            pomodoro.stop_session()
+            self.storage.add_session(
+                ModelSession.new(
+                    self.selected_goal,
+                    self.active_session.start,
+                    self.active_session.duration_sec,
+                )
+            )
+            self.active_session = None
+        else:
+            session = pomodoro.start_session()
+            self.active_session = RunningSession(
+                goal_id=self.selected_goal,
+                start=session.start,
+                duration_sec=session.duration_sec,
+            )
+        self.update_detail()
+
+    async def action_quit(self) -> None:
+        self.exit()
+
+    def _tick(self) -> None:
+        if self.active_session:
+            self.update_detail()
+
+
+def run() -> None:
+    GoalGlideApp().run()
+
+
+__all__ = ["run", "GoalGlideApp"]
+
+if __name__ == "__main__":  # pragma: no cover
+    run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,10 @@ ignore_missing_imports = true
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "goal_glide"
+version = "0.0.0"
+dependencies = [
+    "textual>=0.55",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ tinydb
 pytest
 apscheduler
 notify2
+textual>=0.55

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,0 +1,66 @@
+import asyncio
+import sys
+from datetime import datetime
+
+import pytest
+
+from goal_glide.models.goal import Goal
+from goal_glide.models.storage import Storage
+from goal_glide.services import pomodoro
+
+
+def _setup_textual() -> object | None:
+    if "" in sys.path:
+        sys.path.remove("")
+        sys.path.append("")
+    for key in list(sys.modules):
+        if key == "rich" or key.startswith("rich."):
+            del sys.modules[key]
+    try:
+        from textual.pilot import Pilot
+    except Exception:  # pragma: no cover - textual not installed
+        return None
+    return Pilot
+
+
+@pytest.fixture()
+def app_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    pomodoro.POMO_PATH = tmp_path / "session.json"
+    yield
+
+
+def test_launch_and_quit(app_env):
+    Pilot = _setup_textual()
+    if Pilot is None:
+        pytest.skip("textual not available")
+    from goal_glide.tui import GoalGlideApp
+
+    async def run() -> None:
+        async with Pilot(GoalGlideApp) as pilot:
+            await pilot.press("q")
+            assert pilot.app.is_closed
+
+    asyncio.run(run())
+
+
+def test_toggle_pomo(app_env, tmp_path):
+    Pilot = _setup_textual()
+    if Pilot is None:
+        pytest.skip("textual not available")
+    from goal_glide.tui import GoalGlideApp
+
+    storage = Storage(tmp_path)
+    g = Goal(id="g1", title="g", created=datetime.utcnow())
+    storage.add_goal(g)
+
+    async def run() -> None:
+        async with Pilot(GoalGlideApp) as pilot:
+            await pilot.pause()
+            await pilot.press("s")
+            assert pilot.app.active_session is not None
+            await pilot.press("s")
+            assert pilot.app.active_session is None
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- add Textual dependency
- implement initial TUI with goal list, details and pomodoro controls
- style layout via CSS
- provide basic tests for TUI startup and pomodoro toggle

## Testing
- `mypy goal_glide --strict`
- `ruff check --fix .`
- `black goal_glide/tui.py tests/test_tui.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842859ff2508322b9fc9ae77a679adf