### PR TITLE
feat: reporting (milestone 9)

### DIFF
--- a/goal_glide/services/report.py
+++ b/goal_glide/services/report.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Literal
+
+import pandas as pd
+from jinja2 import Environment, PackageLoader, select_autoescape
+
+from ..models.storage import Storage
+from ..utils.format import format_duration
+from .analytics import current_streak, total_time_by_goal, weekly_histogram
+
+Range = Literal["week", "month", "all"]
+Fmt = Literal["html", "md", "csv"]
+
+__all__ = ["build_report"]
+
+
+def _date_window(range_: Range) -> tuple[date, date]:
+    today = date.today()
+    if range_ == "week":
+        start = today - timedelta(days=today.weekday())
+        end = start + timedelta(days=6)
+    elif range_ == "month":
+        first = today.replace(day=1)
+        prev = first - timedelta(days=1)
+        start = prev.replace(day=1)
+        end = prev
+    else:
+        start = date.min
+        end = today
+    return start, end
+
+
+def build_report(
+    storage: Storage, range_: Range, fmt: Fmt, out_path: Path | None
+) -> Path:
+    start, end = _date_window(range_)
+    goals_sec = total_time_by_goal(storage)
+
+    tag_totals: dict[str, int] = {}
+    for gid, sec in goals_sec.items():
+        g = storage.get_goal(gid)
+        for t in g.tags:
+            tag_totals[t] = tag_totals.get(t, 0) + sec
+
+    hist = weekly_histogram(storage, start)
+    streak = current_streak(storage, end)
+
+    if fmt == "csv":
+        df = pd.DataFrame(
+            [
+                {
+                    "goal_id": gid,
+                    "title": storage.get_goal(gid).title,
+                    "total_sec": sec,
+                    "tags": ",".join(storage.get_goal(gid).tags),
+                }
+                for gid, sec in goals_sec.items()
+            ]
+        )
+        out = out_path or Path.home() / f"GoalGlide_{range_}_{start}_{end}.csv"
+        df.to_csv(out, index=False)
+        return out
+
+    env = Environment(
+        loader=PackageLoader("goal_glide", "templates"), autoescape=select_autoescape()
+    )
+    tpl = env.get_template("report_template.j2")
+    html = tpl.render(
+        start=start,
+        end=end,
+        generated=datetime.now(),
+        total_sec=sum(goals_sec.values()),
+        top_goals=sorted(goals_sec.items(), key=lambda x: x[1], reverse=True)[:5],
+        tag_totals=sorted(tag_totals.items(), key=lambda x: x[1], reverse=True),
+        streak=streak,
+        hist=hist,
+        fmt=fmt,
+        format_duration=format_duration,
+    )
+    out = out_path or Path.home() / f"GoalGlide_{range_}_{start}_{end}.{fmt}"
+    out.write_text(
+        html if fmt == "html" else html.replace("<br>", "  \n"), encoding="utf-8"
+    )
+    return out

--- a/goal_glide/templates/report_template.j2
+++ b/goal_glide/templates/report_template.j2
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+{% if fmt == 'html' %}
+<style>
+body { font-family: sans-serif; margin: 2em; }
+table { border-collapse: collapse; width: 100%; }
+th, td { border: 1px solid #ddd; padding: 4px; }
+th { background: #f0f0f0; }
+</style>
+{% endif %}
+</head>
+<body>
+<h1>Goal Glide Report</h1>
+<p>Period: {{ start }} - {{ end }}<br>Generated: {{ generated.strftime('%Y-%m-%d %H:%M') }}</p>
+<h2>Total Focus Time</h2>
+<p>{{ format_duration(total_sec) }}</p>
+<h2>Top Goals</h2>
+<table>
+<tr><th>Goal ID</th><th>Seconds</th></tr>
+{% for gid, sec in top_goals %}
+<tr><td>{{ gid }}</td><td>{{ sec }}</td></tr>
+{% endfor %}
+</table>
+<h2>Tags</h2>
+<table>
+<tr><th>Tag</th><th>Seconds</th></tr>
+{% for tag, sec in tag_totals %}
+<tr><td>{{ tag }}</td><td>{{ sec }}</td></tr>
+{% endfor %}
+</table>
+<h2>Streak</h2>
+<p>{{ streak }}</p>
+<h2>Histogram</h2>
+<table>
+<tr><th>Date</th><th>Seconds</th></tr>
+{% for d, sec in hist.items() %}
+<tr><td>{{ d }}</td><td>{{ sec }}</td></tr>
+{% endfor %}
+</table>
+</body>
+</html>

--- a/goal_glide/utils/format.py
+++ b/goal_glide/utils/format.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 
 def format_duration(sec: int) -> str:
+    """Format seconds as HH:MM."""
     h, m = divmod(sec // 60, 60)
-    return f"{h} h {m:02} m"
+    return f"{h:d}:{m:02d}"
 
 
 __all__ = ["format_duration"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,4 +17,6 @@ name = "goal_glide"
 version = "0.0.0"
 dependencies = [
     "textual>=0.55",
+    "jinja2>=3.1",
+    "pandas>=2.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ pytest
 apscheduler
 notify2
 textual>=0.55
+jinja2>=3.1
+pandas>=2.0

--- a/rich/__init__.py
+++ b/rich/__init__.py
@@ -1,5 +1,6 @@
 from .bar import Bar
 from .console import Console
+from .progress import Progress, SpinnerColumn, TextColumn
 from .table import Table
 
-__all__ = ["Console", "Table", "Bar"]
+__all__ = ["Console", "Table", "Bar", "Progress", "SpinnerColumn", "TextColumn"]

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -1,0 +1,23 @@
+class SpinnerColumn:
+    pass
+
+
+class TextColumn:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class Progress:
+    def __init__(self, *columns: object) -> None:
+        self.columns = columns
+
+    def __enter__(self) -> "Progress":
+        return self
+
+    def __exit__(
+        self, exc_type: type | None, exc: BaseException | None, tb: object | None
+    ) -> None:  # pragma: no cover
+        pass
+
+    def add_task(self, description: str, total: int | None = None) -> None:
+        print(description)

--- a/tests/test_report_cli.py
+++ b/tests/test_report_cli.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from goal_glide import cli
+from goal_glide.models.goal import Goal
+from goal_glide.models.session import PomodoroSession
+from goal_glide.models.storage import Storage
+from goal_glide.services import report
+
+
+@pytest.fixture()
+def runner(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> CliRunner:
+    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
+    return CliRunner()
+
+
+class FakeDate(date):
+    @classmethod
+    def today(cls) -> date:  # type: ignore[override]
+        return date(2023, 6, 14)
+
+
+def seed(storage: Storage) -> None:
+    storage.add_goal(Goal(id="g", title="A", created=datetime.now()))
+    start = datetime.combine(FakeDate.today(), datetime.min.time())
+    storage.add_session(
+        PomodoroSession(id="s", goal_id="g", start=start, duration_sec=600)
+    )
+
+
+def test_cli_creates_html(
+    tmp_path: Path, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(report, "date", FakeDate)
+    storage = Storage(tmp_path)
+    seed(storage)
+    out = tmp_path / "rep.html"
+    result = runner.invoke(
+        cli.goal,
+        ["report", "make", "--out", str(out)],
+        env={"GOAL_GLIDE_DB_DIR": str(tmp_path)},
+    )
+    assert result.exit_code == 0
+    assert out.exists()
+    assert "Report saved to" in result.output
+
+
+def test_cli_flag_collision(runner: CliRunner) -> None:
+    result = runner.invoke(cli.goal, ["report", "make", "--week", "--month"])
+    assert result.exit_code != 0
+    assert "only one" in result.output

--- a/tests/test_report_service.py
+++ b/tests/test_report_service.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from goal_glide.models.goal import Goal
+from goal_glide.models.session import PomodoroSession
+from goal_glide.models.storage import Storage
+from goal_glide.services import report
+
+
+class FakeDate(date):
+    @classmethod
+    def today(cls) -> date:  # type: ignore[override]
+        return date(2023, 6, 14)
+
+
+def seed(storage: Storage) -> None:
+    g1 = Goal(id="g1", title="A", created=datetime(2023, 6, 1), tags=["work"])
+    g2 = Goal(id="g2", title="B", created=datetime(2023, 6, 1), tags=["play"])
+    g3 = Goal(id="g3", title="C", created=datetime(2023, 6, 1), tags=["work"])
+    for g in (g1, g2, g3):
+        storage.add_goal(g)
+    week_start = FakeDate.today() - timedelta(days=FakeDate.today().weekday())
+    storage.add_session(
+        PomodoroSession(
+            id="s1",
+            goal_id="g1",
+            start=datetime.combine(week_start, datetime.min.time()),
+            duration_sec=600,
+        )
+    )
+    storage.add_session(
+        PomodoroSession(
+            id="s2",
+            goal_id="g2",
+            start=datetime.combine(week_start + timedelta(days=1), datetime.min.time()),
+            duration_sec=1200,
+        )
+    )
+    storage.add_session(
+        PomodoroSession(
+            id="s3",
+            goal_id="g3",
+            start=datetime.combine(week_start + timedelta(days=2), datetime.min.time()),
+            duration_sec=1800,
+        )
+    )
+
+
+def test_date_window_week_month_all(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(report, "date", FakeDate)
+    start, end = report._date_window("week")
+    assert start == date(2023, 6, 12) and end == date(2023, 6, 18)
+    start, end = report._date_window("month")
+    assert start == date(2023, 5, 1) and end == date(2023, 5, 31)
+    start, end = report._date_window("all")
+    assert start == date.min and end == FakeDate.today()
+
+
+def test_csv_output_rows_and_headers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(report, "date", FakeDate)
+    storage = Storage(tmp_path)
+    seed(storage)
+    out = report.build_report(storage, "week", "csv", tmp_path / "r.csv")
+    df = pd.read_csv(out)
+    assert list(df.columns) == ["goal_id", "title", "total_sec", "tags"]
+    assert len(df) == 3
+
+
+def test_html_contains_sections(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(report, "date", FakeDate)
+    storage = Storage(tmp_path)
+    seed(storage)
+    out = report.build_report(storage, "week", "html", tmp_path / "r.html")
+    text = out.read_text()
+    assert "Total Focus Time" in text
+    assert "Top Goals" in text
+    assert "Histogram" in text
+
+
+def test_markdown_formatting(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(report, "date", FakeDate)
+    storage = Storage(tmp_path)
+    seed(storage)
+    out = report.build_report(storage, "week", "md", tmp_path / "r.md")
+    text = out.read_text()
+    assert "  \n" in text
+    assert "<br>" not in text


### PR DESCRIPTION
## Summary
- add report generation service with Markdown, HTML or CSV output
- create shared Jinja2 template for HTML/Markdown reports
- extend CLI with `report make` command
- enhance duration formatting utility
- add lightweight `rich.progress` stub
- implement tests for reporting features

## Testing
- `ruff check --fix .`
- `isort goal_glide/cli.py goal_glide/services/report.py tests/test_report_cli.py tests/test_report_service.py rich/progress.py rich/__init__.py`
- `black goal_glide/cli.py goal_glide/services/report.py tests/test_report_cli.py tests/test_report_service.py rich/progress.py rich/__init__.py`
- `mypy goal_glide --strict`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68428a1fe268832299190ad559997ef2