### PR TITLE
Add comprehensive unit tests

### DIFF
--- a/tests/test_config_module.py
+++ b/tests/test_config_module.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+import pytest
+
+from goal_glide import config
+
+
+@pytest.fixture()
+def cfg_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    path = tmp_path / "config.toml"
+    monkeypatch.setattr(config, "_CONFIG_PATH", path)
+    config._CONFIG_CACHE = None
+    return path
+
+
+def test_default_values_when_file_missing(cfg_path: Path) -> None:
+    assert config.quotes_enabled() is True
+    assert config.reminders_enabled() is False
+    assert config.reminder_break() == 5
+    assert config.reminder_interval() == 30
+    assert config.load_config() == config.DEFAULTS
+
+
+def test_save_and_load_roundtrip(cfg_path: Path) -> None:
+    new_cfg = {
+        "quotes_enabled": False,
+        "reminders_enabled": True,
+        "reminder_break_min": 10,
+        "reminder_interval_min": 20,
+    }
+    config.save_config(new_cfg)
+    config._CONFIG_CACHE = None
+    loaded = config.load_config()
+    assert loaded["quotes_enabled"] == "false"
+    assert loaded["reminders_enabled"] == "true"
+    text = cfg_path.read_text()
+    assert "quotes_enabled = 'false'" in text
+    assert "reminders_enabled = 'true'" in text

--- a/tests/test_main_module.py
+++ b/tests/test_main_module.py
@@ -1,0 +1,14 @@
+import runpy
+
+import pytest
+
+
+def test_main_invokes_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = []
+
+    def fake_cli() -> None:
+        called.append(True)
+
+    monkeypatch.setattr("goal_glide.cli.cli", fake_cli)
+    runpy.run_module("goal_glide.__main__", run_name="__main__")
+    assert called == [True]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+
+from goal_glide.models.goal import Goal, Priority
+from goal_glide.models.session import PomodoroSession
+from goal_glide.models.thought import Thought
+
+
+def test_goal_defaults() -> None:
+    g = Goal(id="1", title="t", created=datetime.utcnow())
+    assert g.priority == Priority.medium
+    assert g.archived is False
+    assert g.tags == []
+
+
+def test_session_new_generates_id() -> None:
+    s = PomodoroSession.new("g", datetime.utcnow(), 60)
+    assert s.goal_id == "g"
+    assert s.duration_sec == 60
+    assert isinstance(s.id, str) and len(s.id) > 0
+
+
+def test_thought_new_trims() -> None:
+    t = Thought.new(" text ", None)
+    assert t.text == "text"
+    assert t.goal_id is None

--- a/tests/test_render_service.py
+++ b/tests/test_render_service.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+
+from goal_glide.models.goal import Goal, Priority
+from goal_glide.services.render import render_goals
+
+
+def test_render_goals_row_count() -> None:
+    goals = [
+        Goal(id="1", title="A", created=datetime.utcnow(), priority=Priority.low),
+        Goal(id="2", title="B", created=datetime.utcnow(), archived=True),
+    ]
+    table = render_goals(goals)
+    assert len(table.rows) == len(goals)
+    assert table.columns[0] == "ID"

--- a/tests/test_root_storage.py
+++ b/tests/test_root_storage.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+
+from dataclasses import dataclass
+
+from goal_glide.models.goal import Priority
+from goal_glide.storage import Storage
+
+
+@dataclass
+class FakeGoal:
+    id: str
+    title: str
+    created: datetime
+    priority: str = "medium"
+    archived: bool = False
+
+
+def test_crud_operations(tmp_path):
+    store = Storage(tmp_path / "db.json")
+    g1 = FakeGoal(id="1", title="A", created=datetime.utcnow(), priority=Priority.high.value)
+    store.add_goal(g1)
+    assert [g.id for g in store.list_goals()] == ["1"]
+    assert store.find_by_title("A").id == "1"
+    assert store.remove_goal("1") is True
+    assert list(store.list_goals()) == []
+
+
+def test_list_filters(tmp_path):
+    store = Storage(tmp_path / "db.json")
+    g1 = FakeGoal(id="1", title="a", created=datetime.utcnow(), priority=Priority.low.value)
+    g2 = FakeGoal(id="2", title="b", created=datetime.utcnow(), archived=True, priority=Priority.high.value)
+    store.add_goal(g1)
+    store.add_goal(g2)
+    assert len(list(store.list_goals())) == 1
+    assert len(list(store.list_goals(include_archived=True))) == 2
+    assert len(list(store.list_goals(archived_only=True))) == 1
+    assert len(list(store.list_goals(priority="high", include_archived=True))) == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,28 @@
+from datetime import datetime, timedelta
+
+import pytest
+
+from goal_glide.utils import format as fmt
+from goal_glide.utils import timefmt
+from goal_glide.utils import tag
+from goal_glide.exceptions import InvalidTagError
+
+
+def test_format_duration_basic() -> None:
+    assert fmt.format_duration(0) == "0:00"
+    assert fmt.format_duration(3661) == "1:01"
+
+
+def test_natural_delta_formats(monkeypatch: pytest.MonkeyPatch) -> None:
+    fixed_now = datetime(2023, 1, 2, 12, 0, 0)
+    monkeypatch.setattr(timefmt, "datetime", type("D", (), {"now": staticmethod(lambda: fixed_now)})())
+    assert timefmt.natural_delta(fixed_now - timedelta(seconds=30)) == "<1m ago"
+    assert timefmt.natural_delta(fixed_now - timedelta(minutes=5)) == "5m ago"
+    assert timefmt.natural_delta(fixed_now - timedelta(hours=2)) == "2h ago"
+    assert timefmt.natural_delta(fixed_now - timedelta(days=3)) == "3d ago"
+
+
+def test_validate_tag() -> None:
+    assert tag.validate_tag("work") == "work"
+    with pytest.raises(InvalidTagError):
+        tag.validate_tag("BAD@TAG")


### PR DESCRIPTION
## Summary
- add tests for config, utils, render service, root storage, models and main

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843e91d1d008322a37c392e9cfd4ebd