### PR TITLE
Fix tag retention across archive actions

### DIFF
--- a/goal_glide/models/storage.py
+++ b/goal_glide/models/storage.py
@@ -133,6 +133,7 @@ class Storage:
             created=goal.created,
             priority=goal.priority,
             archived=True,
+            tags=goal.tags,
         )
         self.update_goal(updated)
         return updated
@@ -147,6 +148,7 @@ class Storage:
             created=goal.created,
             priority=goal.priority,
             archived=False,
+            tags=goal.tags,
         )
         self.update_goal(updated)
         return updated

--- a/tests/test_goal_archive.py
+++ b/tests/test_goal_archive.py
@@ -70,3 +70,13 @@ def test_errors_on_double_archive(tmp_path: Path, runner: CliRunner) -> None:
     result = runner.invoke(goal, ["archive", gid])
     assert result.exit_code != 0
     assert "already archived" in result.output
+
+
+def test_archive_restore_keeps_tags(tmp_path: Path, runner: CliRunner) -> None:
+    runner.invoke(goal, ["add", "g"])
+    gid = Storage(tmp_path).list_goals()[0].id
+    runner.invoke(goal, ["tag", "add", gid, "a", "b"])
+    runner.invoke(goal, ["archive", gid])
+    assert Storage(tmp_path).get_goal(gid).tags == ["a", "b"]
+    runner.invoke(goal, ["restore", gid])
+    assert Storage(tmp_path).get_goal(gid).tags == ["a", "b"]


### PR DESCRIPTION
## Summary
- keep goal tags when archiving or restoring a goal
- test that tags persist through archive and restore

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844b0d160408322ac1d8243a11cfd67