### PR TITLE
Fix formatting

### DIFF
--- a/tests/test_root_storage.py
+++ b/tests/test_root_storage.py
@@ -17,7 +17,9 @@ class FakeGoal:
 
 def test_crud_operations(tmp_path):
     store = Storage(tmp_path / "db.json")
-    g1 = FakeGoal(id="1", title="A", created=datetime.utcnow(), priority=Priority.high.value)
+    g1 = FakeGoal(
+        id="1", title="A", created=datetime.utcnow(), priority=Priority.high.value
+    )
     store.add_goal(g1)
     assert [g.id for g in store.list_goals()] == ["1"]
     assert store.find_by_title("A").id == "1"
@@ -27,8 +29,16 @@ def test_crud_operations(tmp_path):
 
 def test_list_filters(tmp_path):
     store = Storage(tmp_path / "db.json")
-    g1 = FakeGoal(id="1", title="a", created=datetime.utcnow(), priority=Priority.low.value)
-    g2 = FakeGoal(id="2", title="b", created=datetime.utcnow(), archived=True, priority=Priority.high.value)
+    g1 = FakeGoal(
+        id="1", title="a", created=datetime.utcnow(), priority=Priority.low.value
+    )
+    g2 = FakeGoal(
+        id="2",
+        title="b",
+        created=datetime.utcnow(),
+        archived=True,
+        priority=Priority.high.value,
+    )
     store.add_goal(g1)
     store.add_goal(g2)
     assert len(list(store.list_goals())) == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,9 @@ def test_format_duration_basic() -> None:
 
 def test_natural_delta_formats(monkeypatch: pytest.MonkeyPatch) -> None:
     fixed_now = datetime(2023, 1, 2, 12, 0, 0)
-    monkeypatch.setattr(timefmt, "datetime", type("D", (), {"now": staticmethod(lambda: fixed_now)})())
+    monkeypatch.setattr(
+        timefmt, "datetime", type("D", (), {"now": staticmethod(lambda: fixed_now)})()
+    )
     assert timefmt.natural_delta(fixed_now - timedelta(seconds=30)) == "<1m ago"
     assert timefmt.natural_delta(fixed_now - timedelta(minutes=5)) == "5m ago"
     assert timefmt.natural_delta(fixed_now - timedelta(hours=2)) == "2h ago"


### PR DESCRIPTION
## Summary
- run `black` on failing tests

## Testing
- `pytest tests/test_root_storage.py tests/test_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6844b12f1dfc832295a523835d177b72