### PR TITLE
Align storage module env var

### DIFF
--- a/goal_glide/storage.py
+++ b/goal_glide/storage.py
@@ -11,9 +11,16 @@ TABLE_NAME = "goals"
 
 
 class Storage:
+    """TinyDB wrapper used by CLI tests."""
+
     def __init__(self, path: Optional[Path] = None):
-        env_path = os.environ.get("GOAL_GLIDE_DB")
-        self.path = Path(path or env_path or DB_NAME)
+        env_dir = os.environ.get("GOAL_GLIDE_DB_DIR")
+        if path is not None:
+            self.path = Path(path)
+        else:
+            base = Path(env_dir) if env_dir else Path(".")
+            base.mkdir(parents=True, exist_ok=True)
+            self.path = base / DB_NAME
         self.db: TinyDB = TinyDB(self.path)
         self.table: Table = self.db.table(TABLE_NAME)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,21 +1,19 @@
 from click.testing import CliRunner
 
 from goal_glide.cli import cli
-from goal_glide.storage import DB_NAME
 
 
 def test_add_list_remove(tmp_path):
-    db_path = tmp_path / DB_NAME
     runner = CliRunner()
 
     # add goal
     result = runner.invoke(
-        cli, ["add", "Test Goal"], env={"GOAL_GLIDE_DB": str(db_path)}
+        cli, ["add", "Test Goal"], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)}
     )
     assert result.exit_code == 0
 
     # list
-    result = runner.invoke(cli, ["list"], env={"GOAL_GLIDE_DB": str(db_path)})
+    result = runner.invoke(cli, ["list"], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)})
     assert "Test Goal" in result.output
 
     # remove
@@ -23,6 +21,9 @@ def test_add_list_remove(tmp_path):
     lines = [line for line in result.output.splitlines() if "Test Goal" in line]
     goal_id = lines[0].split()[0]
     result = runner.invoke(
-        cli, ["remove", goal_id], input="y\n", env={"GOAL_GLIDE_DB": str(db_path)}
+        cli,
+        ["remove", goal_id],
+        input="y\n",
+        env={"GOAL_GLIDE_DB_DIR": str(tmp_path)},
     )
     assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- respect `GOAL_GLIDE_DB_DIR` in `goal_glide/storage.py`
- adjust CLI tests to use the new variable

## Testing
- `pip install pandas`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844b1335b308322ad03cd3fb0c637d1