### PR TITLE
Handle booleans correctly in config saving

### DIFF
--- a/goal_glide/config.py
+++ b/goal_glide/config.py
@@ -54,7 +54,10 @@ def save_config(cfg: Dict[str, Any]) -> None:
     _CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
     items = []
     for k, v in cfg.items():
-        items.append(f"{k} = {str(v).lower() if isinstance(v, bool) else v!r}")
+        if isinstance(v, bool):
+            items.append(f"{k} = {str(v).lower()}")
+        else:
+            items.append(f"{k} = {v!r}")
     content = "\n".join(items)
     with _CONFIG_PATH.open("w", encoding="utf-8") as f:
         f.write(content)

--- a/tests/test_config_module.py
+++ b/tests/test_config_module.py
@@ -31,8 +31,8 @@ def test_save_and_load_roundtrip(cfg_path: Path) -> None:
     config.save_config(new_cfg)
     config._CONFIG_CACHE = None
     loaded = config.load_config()
-    assert loaded["quotes_enabled"] == "false"
-    assert loaded["reminders_enabled"] == "true"
+    assert loaded["quotes_enabled"] is False
+    assert loaded["reminders_enabled"] is True
     text = cfg_path.read_text()
-    assert "quotes_enabled = 'false'" in text
-    assert "reminders_enabled = 'true'" in text
+    assert "quotes_enabled = false" in text
+    assert "reminders_enabled = true" in text


### PR DESCRIPTION
## Summary
- save booleans as `true`/`false` in `config.save_config`
- update roundtrip test to expect booleans and new file output

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844b39b81488322a34db20f88f8bf7c