### PR TITLE
Add flake8 linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E402

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,21 @@
+name: Lint
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  flake8:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
+      - name: Run flake8
+        run: flake8

--- a/goal_glide/cli.py
+++ b/goal_glide/cli.py
@@ -289,7 +289,10 @@ def reminder_config(break_: int | None, interval: int | None) -> None:
 def reminder_status() -> None:
     cfg = load_config()
     console.print(
-        f"Enabled: {cfg.get('reminders_enabled', False)} | Break: {cfg.get('reminder_break_min', 5)}m | Interval: {cfg.get('reminder_interval_min', 30)}m"
+        "Enabled: "
+        f"{cfg.get('reminders_enabled', False)} | "
+        f"Break: {cfg.get('reminder_break_min', 5)}m | "
+        f"Interval: {cfg.get('reminder_interval_min', 30)}m"
     )
 
 

--- a/tinydb/__init__.py
+++ b/tinydb/__init__.py
@@ -13,7 +13,8 @@ class Query:
         self._attr = item
         return self
 
-    def __eq__(self, other: Any) -> Callable[[dict[str, Any]], bool]:  # type: ignore[override]
+    def __eq__(self, other: Any) -> Callable[[dict[str, Any]], bool]:
+        # type: ignore[override]
         attr = self._attr
 
         def test(row: dict[str, Any]) -> bool:


### PR DESCRIPTION
## Summary
- configure `flake8` linter and add GitHub Action to run on pushes and PRs
- shorten a long reminder status line in the CLI
- split a long `tinydb` comment line

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844b51b37288322865c80bce04b15f6