### PR TITLE
Add goal option to pomodoro CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,14 @@ python -m goal_glide list --tag writing
 
 ### Pomodoro Sessions
 
-Start and stop a session:
+Start and stop a session (optionally linking it to a goal):
 
 ```bash
-python -m goal_glide pomo start --duration 25
+python -m goal_glide pomo start --duration 25 --goal <goal-id>
 python -m goal_glide pomo stop
 ```
+The `--goal` flag records the session against the specified goal for
+later statistics and reporting.
 
 Motivational quotes are shown on completion when enabled (default). Use `goal config quotes --disable` to turn them off.
 

--- a/goal_glide/cli.py
+++ b/goal_glide/cli.py
@@ -27,7 +27,11 @@ from .models.storage import Storage
 from .models.thought import Thought
 from .services import report
 from .services.analytics import current_streak, total_time_by_goal, weekly_histogram
-from .services.pomodoro import PomodoroSession as SvcSession, start_session, stop_session
+from .services.pomodoro import (
+    PomodoroSession as SvcSession,
+    start_session,
+    stop_session,
+)
 from .models.session import PomodoroSession as ModelSession
 from .services.quotes import get_random_quote
 from .services.render import render_goals
@@ -294,8 +298,11 @@ def reminder_config(break_: int | None, interval: int | None) -> None:
 @reminder_cli.command("status")
 def reminder_status() -> None:
     cfg = load_config()
+    enabled = cfg.get('reminders_enabled', False)
+    break_min = cfg.get('reminder_break_min', 5)
+    interval_min = cfg.get('reminder_interval_min', 30)
     console.print(
-        f"Enabled: {cfg.get('reminders_enabled', False)} | Break: {cfg.get('reminder_break_min', 5)}m | Interval: {cfg.get('reminder_interval_min', 30)}m"
+        f"Enabled: {enabled} | Break: {break_min}m | Interval: {interval_min}m"
     )
 
 

--- a/goal_glide/models/session.py
+++ b/goal_glide/models/session.py
@@ -13,7 +13,15 @@ class PomodoroSession:
     duration_sec: int
 
     @classmethod
-    def new(cls, goal_id: str | None, start: datetime, duration_sec: int) -> "PomodoroSession":
+    def new(
+        cls,
+        goal_id: str | None,
+        start: datetime,
+        duration_sec: int,
+    ) -> "PomodoroSession":
         return cls(
-            id=str(uuid4()), goal_id=goal_id, start=start, duration_sec=duration_sec
+            id=str(uuid4()),
+            goal_id=goal_id,
+            start=start,
+            duration_sec=duration_sec,
         )

--- a/goal_glide/models/session.py
+++ b/goal_glide/models/session.py
@@ -8,12 +8,12 @@ from uuid import uuid4
 @dataclass(slots=True, frozen=True)
 class PomodoroSession:
     id: str
-    goal_id: str
+    goal_id: str | None
     start: datetime
     duration_sec: int
 
     @classmethod
-    def new(cls, goal_id: str, start: datetime, duration_sec: int) -> "PomodoroSession":
+    def new(cls, goal_id: str | None, start: datetime, duration_sec: int) -> "PomodoroSession":
         return cls(
             id=str(uuid4()), goal_id=goal_id, start=start, duration_sec=duration_sec
         )

--- a/goal_glide/models/storage.py
+++ b/goal_glide/models/storage.py
@@ -70,7 +70,7 @@ class Storage:
             st_dt = st
         return PomodoroSession(
             id=row["id"],
-            goal_id=row["goal_id"],
+            goal_id=row.get("goal_id"),
             start=st_dt,
             duration_sec=row["duration_sec"],
         )

--- a/goal_glide/services/analytics.py
+++ b/goal_glide/services/analytics.py
@@ -17,7 +17,7 @@ def _all_sessions(storage: Storage) -> list[PomodoroSession]:
 def total_time_by_goal(storage: Storage) -> Dict[str, int]:
     acc: Dict[str, int] = defaultdict(int)
     for s in _all_sessions(storage):
-        if s.duration_sec:
+        if s.duration_sec and s.goal_id is not None:
             acc[s.goal_id] += s.duration_sec
     return dict(acc)
 

--- a/goal_glide/services/pomodoro.py
+++ b/goal_glide/services/pomodoro.py
@@ -25,8 +25,15 @@ class PomodoroSession:
     goal_id: str | None = None
 
 
-def start_session(duration_min: int = 25, goal_id: str | None = None) -> PomodoroSession:
-    session = PomodoroSession(start=datetime.now(), duration_sec=duration_min * 60, goal_id=goal_id)
+def start_session(
+    duration_min: int = 25,
+    goal_id: str | None = None,
+) -> PomodoroSession:
+    session = PomodoroSession(
+        start=datetime.now(),
+        duration_sec=duration_min * 60,
+        goal_id=goal_id,
+    )
     POMO_PATH.parent.mkdir(parents=True, exist_ok=True)
     with POMO_PATH.open("w", encoding="utf-8") as fp:
         json.dump(

--- a/goal_glide/services/pomodoro.py
+++ b/goal_glide/services/pomodoro.py
@@ -22,14 +22,19 @@ POMO_PATH = Path.home() / ".goal_glide" / "session.json"
 class PomodoroSession:
     start: datetime
     duration_sec: int
+    goal_id: str | None = None
 
 
-def start_session(duration_min: int = 25) -> PomodoroSession:
-    session = PomodoroSession(start=datetime.now(), duration_sec=duration_min * 60)
+def start_session(duration_min: int = 25, goal_id: str | None = None) -> PomodoroSession:
+    session = PomodoroSession(start=datetime.now(), duration_sec=duration_min * 60, goal_id=goal_id)
     POMO_PATH.parent.mkdir(parents=True, exist_ok=True)
     with POMO_PATH.open("w", encoding="utf-8") as fp:
         json.dump(
-            {"start": session.start.isoformat(), "duration_sec": session.duration_sec},
+            {
+                "start": session.start.isoformat(),
+                "duration_sec": session.duration_sec,
+                "goal_id": session.goal_id,
+            },
             fp,
         )
     for cb in on_new_session:
@@ -43,7 +48,9 @@ def load_session() -> Optional[PomodoroSession]:
     with POMO_PATH.open(encoding="utf-8") as fp:
         data = json.load(fp)
     return PomodoroSession(
-        start=datetime.fromisoformat(data["start"]), duration_sec=data["duration_sec"]
+        start=datetime.fromisoformat(data["start"]),
+        duration_sec=data["duration_sec"],
+        goal_id=data.get("goal_id"),
     )
 
 


### PR DESCRIPTION
## Summary
- allow specifying a goal when starting a pomodoro
- persist completed sessions to storage on stop
- make sessions support optional goal IDs
- document new flag in README
- test that CLI sessions are saved

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844b39d59808322b1e22d913aa062e2