### PR TITLE
Add pre-commit hook setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+- repo: https://github.com/psf/black
+  rev: 23.11.0
+  hooks:
+    - id: black
+      language_version: python3.11
+- repo: https://github.com/pycqa/flake8
+  rev: 6.1.0
+  hooks:
+    - id: flake8
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.8.0
+  hooks:
+    - id: mypy
+      additional_dependencies: [tinydb]
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.5.0
+  hooks:
+    - id: check-yaml
+    - id: end-of-file-fixer
+    - id: trailing-whitespace

--- a/README.md
+++ b/README.md
@@ -163,5 +163,18 @@ git config core.hooksPath .githooks
 With this option enabled, `pytest` and `mypy` will run whenever `git push`
 is invoked and the push will abort if either the tests or type checks fail.
 
+## Pre-commit Hooks
+
+Run style and type checks automatically on each commit by installing
+[pre-commit](https://pre-commit.com/) and enabling the hooks:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+The configured hook runs `black`, `flake8` and `mypy` on staged files so
+issues are caught early.
+
 ---
 Goal Glide is distributed under the terms of the GNU General Public License v3.


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml` for black, flake8 and mypy
- document pre-commit installation in README

## Testing
- `pre-commit run --files README.md .pre-commit-config.yaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844ba8c1a5c83229b72d80ed57676a8