### PR TITLE
Add coverage for disabled reminder scheduling

### DIFF
--- a/tests/test_reminder.py
+++ b/tests/test_reminder.py
@@ -7,7 +7,7 @@ from click.testing import CliRunner
 
 from goal_glide import cli
 from goal_glide import config as cfg
-from goal_glide.services import notify
+from goal_glide.services import notify, reminder
 
 
 @pytest.fixture()
@@ -55,3 +55,10 @@ def test_notification_backend_selection(monkeypatch: pytest.MonkeyPatch) -> None
         monkeypatch.setattr(notify.platform, "system", lambda: osname)
         notify.push("hi")
         assert captured == ["hi"]
+
+
+def test_schedule_after_stop_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(reminder, "_sched", None)
+    monkeypatch.setattr(cfg, "reminders_enabled", lambda: False)
+    reminder.schedule_after_stop()
+    assert reminder._sched is None


### PR DESCRIPTION
## Summary
- add missing import to reminder tests
- add a test ensuring `schedule_after_stop` does nothing when reminders are disabled

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844baba8bf88322b555a8f1b2bc262a