### PR TITLE
Add pomodoro service tests

### DIFF
--- a/tests/test_pomodoro_service.py
+++ b/tests/test_pomodoro_service.py
@@ -25,7 +25,9 @@ def _patch_now(monkeypatch: pytest.MonkeyPatch, when: datetime) -> None:
     monkeypatch.setattr(pomodoro, "datetime", FakeDT)
 
 
-def test_start_session_writes_file(monkeypatch: pytest.MonkeyPatch, session_path: Path) -> None:
+def test_start_session_writes_file(
+    monkeypatch: pytest.MonkeyPatch, session_path: Path
+) -> None:
     fake_now = datetime(2023, 1, 1, 12, 0, 0)
     _patch_now(monkeypatch, fake_now)
     session = pomodoro.start_session(1)
@@ -37,7 +39,9 @@ def test_start_session_writes_file(monkeypatch: pytest.MonkeyPatch, session_path
     assert data == {"start": fake_now.isoformat(), "duration_sec": 60}
 
 
-def test_load_session_returns_equivalent(monkeypatch: pytest.MonkeyPatch, session_path: Path) -> None:
+def test_load_session_returns_equivalent(
+    monkeypatch: pytest.MonkeyPatch, session_path: Path
+) -> None:
     fake_now = datetime(2023, 1, 1, 13, 0, 0)
     _patch_now(monkeypatch, fake_now)
     original = pomodoro.start_session(1)
@@ -45,7 +49,9 @@ def test_load_session_returns_equivalent(monkeypatch: pytest.MonkeyPatch, sessio
     assert loaded == original
 
 
-def test_stop_session_deletes_file(monkeypatch: pytest.MonkeyPatch, session_path: Path) -> None:
+def test_stop_session_deletes_file(
+    monkeypatch: pytest.MonkeyPatch, session_path: Path
+) -> None:
     fake_now = datetime(2023, 1, 1, 14, 0, 0)
     _patch_now(monkeypatch, fake_now)
     original = pomodoro.start_session(1)

--- a/tests/test_pomodoro_service.py
+++ b/tests/test_pomodoro_service.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from goal_glide.services import pomodoro
+
+
+@pytest.fixture()
+def session_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    path = tmp_path / "session.json"
+    monkeypatch.setattr(pomodoro, "POMO_PATH", path)
+    return path
+
+
+def _patch_now(monkeypatch: pytest.MonkeyPatch, when: datetime) -> None:
+    class FakeDT(datetime):
+        @classmethod
+        def now(cls) -> datetime:  # type: ignore[override]
+            return when
+
+    monkeypatch.setattr(pomodoro, "datetime", FakeDT)
+
+
+def test_start_session_writes_file(monkeypatch: pytest.MonkeyPatch, session_path: Path) -> None:
+    fake_now = datetime(2023, 1, 1, 12, 0, 0)
+    _patch_now(monkeypatch, fake_now)
+    session = pomodoro.start_session(1)
+    assert isinstance(session, pomodoro.PomodoroSession)
+    assert session.start == fake_now
+    assert session.duration_sec == 60
+    assert session_path.exists()
+    data = json.loads(session_path.read_text())
+    assert data == {"start": fake_now.isoformat(), "duration_sec": 60}
+
+
+def test_load_session_returns_equivalent(monkeypatch: pytest.MonkeyPatch, session_path: Path) -> None:
+    fake_now = datetime(2023, 1, 1, 13, 0, 0)
+    _patch_now(monkeypatch, fake_now)
+    original = pomodoro.start_session(1)
+    loaded = pomodoro.load_session()
+    assert loaded == original
+
+
+def test_stop_session_deletes_file(monkeypatch: pytest.MonkeyPatch, session_path: Path) -> None:
+    fake_now = datetime(2023, 1, 1, 14, 0, 0)
+    _patch_now(monkeypatch, fake_now)
+    original = pomodoro.start_session(1)
+    stopped = pomodoro.stop_session()
+    assert stopped == original
+    assert not session_path.exists()
+
+
+def test_stop_session_no_file_raises(session_path: Path) -> None:
+    with pytest.raises(RuntimeError):
+        pomodoro.stop_session()

--- a/tests/test_pomodoro_service.py
+++ b/tests/test_pomodoro_service.py
@@ -36,7 +36,8 @@ def test_start_session_writes_file(
     assert session.duration_sec == 60
     assert session_path.exists()
     data = json.loads(session_path.read_text())
-    assert data == {"start": fake_now.isoformat(), "duration_sec": 60}
+    assert data["start"] == fake_now.isoformat()
+    assert data["duration_sec"] == 60
 
 
 def test_load_session_returns_equivalent(


### PR DESCRIPTION
## Summary
- add unit tests for pomodoro service

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844bab88b588322a291f34d5441887d