### PR TITLE
Remove unused exception classes

### DIFF
--- a/goal_glide/exceptions.py
+++ b/goal_glide/exceptions.py
@@ -10,13 +10,5 @@ class GoalNotArchivedError(ValueError):
     pass
 
 
-class EmptyThoughtError(ValueError):
-    pass
-
-
-class GoalDoesNotExistError(ValueError):
-    pass
-
-
 class InvalidTagError(ValueError):
     pass


### PR DESCRIPTION
## Summary
- delete `EmptyThoughtError` and `GoalDoesNotExistError`
- keep remaining exceptions with consistent spacing

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844baa6fa1c8322aa94d0038fe12361