### PR TITLE
Add CLI config show command

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Configuration is kept in `~/.goal_glide/config.toml` and controls:
 - `reminder_interval_min` – how often to prompt for another session
 
 Run `python -m goal_glide config quotes --enable/--disable` or the reminder commands shown above to modify these settings.
+Run `python -m goal_glide config show` to view the current configuration.
 
 ## Troubleshooting
 

--- a/goal_glide/cli.py
+++ b/goal_glide/cli.py
@@ -314,6 +314,18 @@ def cfg_quotes(enable: bool | None) -> None:
     console.print(f"Quotes are {'ON' if cfg.get('quotes_enabled', True) else 'OFF'}")
 
 
+@config.command("show")
+def cfg_show() -> None:
+    """Show current configuration."""
+    cfg = load_config()
+    table = Table(title="Config")
+    table.add_column("Key")
+    table.add_column("Value")
+    for key, value in cfg.items():
+        table.add_row(key, str(value))
+    console.print(table)
+
+
 goal.add_command(config)
 
 

--- a/tests/test_config_module.py
+++ b/tests/test_config_module.py
@@ -2,7 +2,8 @@ from pathlib import Path
 
 import pytest
 
-from goal_glide import config
+from goal_glide import cli, config
+from click.testing import CliRunner
 
 
 @pytest.fixture()
@@ -36,3 +37,20 @@ def test_save_and_load_roundtrip(cfg_path: Path) -> None:
     text = cfg_path.read_text()
     assert "quotes_enabled = false" in text
     assert "reminders_enabled = true" in text
+
+
+def test_show_command_outputs_all_settings(cfg_path: Path) -> None:
+    cfg = {
+        "quotes_enabled": False,
+        "reminders_enabled": True,
+        "reminder_break_min": 10,
+        "reminder_interval_min": 20,
+    }
+    config.save_config(cfg)
+    config._CONFIG_CACHE = None
+    runner = CliRunner()
+    result = runner.invoke(cli.goal, ["config", "show"])
+    assert result.exit_code == 0
+    for k, v in cfg.items():
+        assert k in result.output
+        assert str(v) in result.output


### PR DESCRIPTION
## Summary
- add `config show` command to print current settings
- mention the command in the README
- test that the command outputs all settings

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844baa6092883229fd899eff50e1673