### PR TITLE
Add pomodoro status command

### DIFF
--- a/goal_glide/cli.py
+++ b/goal_glide/cli.py
@@ -27,7 +27,12 @@ from .models.storage import Storage
 from .models.thought import Thought
 from .services import report
 from .services.analytics import current_streak, total_time_by_goal, weekly_histogram
-from .services.pomodoro import PomodoroSession, start_session, stop_session
+from .services.pomodoro import (
+    PomodoroSession,
+    load_session,
+    start_session,
+    stop_session,
+)
 from .services.quotes import get_random_quote
 from .services.render import render_goals
 from .utils.format import format_duration
@@ -237,6 +242,19 @@ def start_pomo(duration: int) -> None:
 def stop_pomo() -> None:
     session = stop_session()
     _print_completion(session)
+
+
+@pomo.command("status")
+@handle_exceptions
+def status_pomo() -> None:
+    """Show current pomodoro progress."""
+    session = load_session()
+    if session is None:
+        console.print("No active session")
+        return
+    elapsed = int((datetime.now() - session.start).total_seconds())
+    remaining = max(session.duration_sec - elapsed, 0)
+    console.print(f"Elapsed {_fmt(elapsed)}, remaining {_fmt(remaining)}")
 
 
 goal.add_command(pomo)

--- a/tests/test_pomo_status.py
+++ b/tests/test_pomo_status.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from goal_glide import cli
+from goal_glide import config as cfg
+
+
+@pytest.fixture()
+def runner(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> CliRunner:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
+    cfg._CONFIG_PATH = tmp_path / ".goal_glide" / "config.toml"
+    cfg._CONFIG_CACHE = None
+    return CliRunner()
+
+
+def test_status_shows_time(monkeypatch: pytest.MonkeyPatch, runner: CliRunner) -> None:
+    runner.invoke(cli.goal, ["pomo", "start", "--duration", "2"])
+    result = runner.invoke(cli.goal, ["pomo", "status"])
+    assert "remaining" in result.output.lower()
+    assert "2m" in result.output
+    runner.invoke(cli.goal, ["pomo", "stop"])
+
+
+def test_status_no_session(runner: CliRunner) -> None:
+    result = runner.invoke(cli.goal, ["pomo", "status"])
+    assert "no active session" in result.output.lower()


### PR DESCRIPTION
## Summary
- show elapsed and remaining time in a `pomo status` command
- test `pomo status` with and without an active session

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844baa4b4f483228194bb43240d6f2f