### PR TITLE
Add goal tag listing feature

### DIFF
--- a/goal_glide/cli.py
+++ b/goal_glide/cli.py
@@ -186,6 +186,22 @@ def tag_rm(goal_id: str, tag: str) -> None:
     console.print(f"Tags for {updated.id}: {', '.join(updated.tags)}")
 
 
+@tag.command("list")
+def tag_list() -> None:
+    """List all tags with goal counts."""
+    storage = get_storage()
+    tags = storage.list_all_tags()
+    if not tags:
+        console.print("No tags.")
+        return
+    table = Table(title="Tags")
+    table.add_column("Tag")
+    table.add_column("Goals")
+    for name, count in sorted(tags.items()):
+        table.add_row(name, str(count))
+    console.print(table)
+
+
 @goal.command("list")
 @click.option("--archived", is_flag=True, help="Show only archived goals")
 @click.option(

--- a/goal_glide/models/storage.py
+++ b/goal_glide/models/storage.py
@@ -174,6 +174,14 @@ class Storage:
             results.append(g)
         return results
 
+    def list_all_tags(self) -> dict[str, int]:
+        """Return mapping of tag name to count of goals containing it."""
+        counts: dict[str, int] = {}
+        for row in self.table.all():
+            for tag in row.get("tags", []):
+                counts[tag] = counts.get(tag, 0) + 1
+        return counts
+
     def remove_goal(self, goal_id: str) -> None:
         if not self.table.contains(Query().id == goal_id):
             raise GoalNotFoundError(f"Goal {goal_id} not found")

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -77,3 +77,16 @@ def test_list_filter_multiple_tags_and_logic(tmp_path: Path, runner: CliRunner) 
     runner.invoke(goal, ["tag", "add", gid2, "a"])
     result = runner.invoke(goal, ["list", "--tag", "a", "--tag", "b"])
     assert "g1" in result.output and "g2" not in result.output
+
+
+def test_tag_list_counts(tmp_path: Path, runner: CliRunner) -> None:
+    runner.invoke(goal, ["add", "g1"])
+    runner.invoke(goal, ["add", "g2"])
+    goals = Storage(tmp_path).list_goals()
+    runner.invoke(goal, ["tag", "add", goals[0].id, "work", "fun"])
+    runner.invoke(goal, ["tag", "add", goals[1].id, "work"])
+    result = runner.invoke(goal, ["tag", "list"])
+    assert result.exit_code == 0
+    rows = [line for line in result.output.splitlines() if "|" in line][1:]
+    assert any("work" in r and "2" in r for r in rows)
+    assert any("fun" in r and "1" in r for r in rows)


### PR DESCRIPTION
## Summary
- list tags with counts via `goal tag list`
- return tag counts from storage
- test tag listing output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844baa4b088832286cd6756c13603f1