### PR TITLE
Add goal update subcommand

### DIFF
--- a/goal_glide/cli.py
+++ b/goal_glide/cli.py
@@ -158,6 +158,42 @@ def restore_goal_cmd(goal_id: str) -> None:
     console.print(f":package: Goal {goal_id} restored")
 
 
+@goal.command("update")
+@click.argument("goal_id")
+@click.option("--title", help="New goal title")
+@click.option(
+    "--priority",
+    type=click.Choice([e.value for e in Priority]),
+    help="Goal priority (low, medium, high)",
+)
+@handle_exceptions
+def update_goal_cmd(goal_id: str, title: str | None, priority: str | None) -> None:
+    """Modify goal attributes."""
+    storage = get_storage()
+    goal = storage.get_goal(goal_id)
+
+    new_title = goal.title
+    if title is not None:
+        title = title.strip()
+        if not title:
+            console.print("[red]Title cannot be empty.[/red]")
+            raise SystemExit(1)
+        new_title = title
+
+    new_priority = goal.priority if priority is None else Priority(priority)
+
+    updated = Goal(
+        id=goal.id,
+        title=new_title,
+        created=goal.created,
+        priority=new_priority,
+        archived=goal.archived,
+        tags=goal.tags,
+    )
+    storage.update_goal(updated)
+    console.print(f":pencil: Updated goal {updated.id}")
+
+
 @goal.group("tag")
 def tag() -> None:
     """Tag management."""

--- a/tests/test_goal_update.py
+++ b/tests/test_goal_update.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from goal_glide.cli import goal
+from goal_glide.models.goal import Priority
+from goal_glide.models.storage import Storage
+
+
+@pytest.fixture()
+def runner(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> CliRunner:
+    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
+    return CliRunner()
+
+
+def test_update_title(tmp_path: Path, runner: CliRunner) -> None:
+    runner.invoke(goal, ["add", "old title"])
+    gid = Storage(tmp_path).list_goals()[0].id
+    result = runner.invoke(goal, ["update", gid, "--title", "new title"])
+    assert result.exit_code == 0
+    assert Storage(tmp_path).get_goal(gid).title == "new title"
+
+
+def test_update_priority(tmp_path: Path, runner: CliRunner) -> None:
+    runner.invoke(goal, ["add", "g"])
+    gid = Storage(tmp_path).list_goals()[0].id
+    result = runner.invoke(goal, ["update", gid, "--priority", "high"])
+    assert result.exit_code == 0
+    assert Storage(tmp_path).get_goal(gid).priority == Priority.high


### PR DESCRIPTION
## Summary
- add CLI command `goal update` for modifying goal title and priority
- test updating goal title and priority

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844ddfe65e08322a00abb6d650d7f10