### PR TITLE
Refactor pomodoro sessions

### DIFF
--- a/goal_glide/cli.py
+++ b/goal_glide/cli.py
@@ -27,12 +27,8 @@ from .models.storage import Storage
 from .models.thought import Thought
 from .services import report
 from .services.analytics import current_streak, total_time_by_goal, weekly_histogram
-from .services.pomodoro import (
-    PomodoroSession as SvcSession,
-    start_session,
-    stop_session,
-)
-from .models.session import PomodoroSession as ModelSession
+from .services.pomodoro import start_session, stop_session
+from .models.session import PomodoroSession
 from .services.quotes import get_random_quote
 from .services.render import render_goals
 from .utils.format import format_duration
@@ -81,7 +77,7 @@ def _fmt(seconds: int) -> str:
     return f"{mins}m"
 
 
-def _print_completion(session: SvcSession) -> None:
+def _print_completion(session: PomodoroSession) -> None:
     console.print(f"Pomodoro complete ✅ ({_fmt(session.duration_sec)})")
     if quotes_enabled():
         quote, author = get_random_quote()
@@ -296,7 +292,7 @@ def stop_pomo() -> None:
     session = stop_session()
     storage = get_storage()
     storage.add_session(
-        ModelSession.new(session.goal_id, session.start, session.duration_sec)
+        PomodoroSession.new(session.goal_id, session.start, session.duration_sec)
     )
     _print_completion(session)
 

--- a/goal_glide/services/pomodoro.py
+++ b/goal_glide/services/pomodoro.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Callable, Optional
@@ -9,6 +8,7 @@ from typing import Callable, Optional
 from rich.console import Console
 
 from .. import config
+from ..models.session import PomodoroSession
 
 console = Console()
 
@@ -18,21 +18,15 @@ on_session_end: list[Callable[[], None]] = []
 POMO_PATH = Path.home() / ".goal_glide" / "session.json"
 
 
-@dataclass(slots=True)
-class PomodoroSession:
-    start: datetime
-    duration_sec: int
-    goal_id: str | None = None
-
-
 def start_session(
     duration_min: int = 25,
     goal_id: str | None = None,
 ) -> PomodoroSession:
     session = PomodoroSession(
+        id="",
+        goal_id=goal_id,
         start=datetime.now(),
         duration_sec=duration_min * 60,
-        goal_id=goal_id,
     )
     POMO_PATH.parent.mkdir(parents=True, exist_ok=True)
     with POMO_PATH.open("w", encoding="utf-8") as fp:
@@ -55,9 +49,10 @@ def load_session() -> Optional[PomodoroSession]:
     with POMO_PATH.open(encoding="utf-8") as fp:
         data = json.load(fp)
     return PomodoroSession(
+        id="",
+        goal_id=data.get("goal_id"),
         start=datetime.fromisoformat(data["start"]),
         duration_sec=data["duration_sec"],
-        goal_id=data.get("goal_id"),
     )
 
 

--- a/goal_glide/tui.py
+++ b/goal_glide/tui.py
@@ -17,7 +17,7 @@ from textual.widgets import DataTable, Footer, Header, Static
 
 from .cli import get_storage
 from .models.goal import Goal, Priority
-from .models.session import PomodoroSession as ModelSession
+from .models.session import PomodoroSession
 from .models.thought import Thought
 from .services import pomodoro
 
@@ -125,7 +125,7 @@ class GoalGlideApp(App[None]):
         if self.active_session and self.active_session.goal_id == self.selected_goal:
             pomodoro.stop_session()
             self.storage.add_session(
-                ModelSession.new(
+                PomodoroSession.new(
                     self.selected_goal,
                     self.active_session.start,
                     self.active_session.duration_sec,


### PR DESCRIPTION
## Summary
- remove the service-level PomodoroSession dataclass
- track sessions using models.session.PomodoroSession
- update CLI and TUI imports to use the shared model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844df417154832283da1259531f2dc9