### PR TITLE
Add pytest coverage checks

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,6 +1,6 @@
 #!/bin/sh
-# Run tests and type checks before pushing
-pytest
+# Run tests with coverage and type checks before pushing
+pytest --cov=goal_glide --cov-report=term-missing --cov-fail-under=80
 status=$?
 if [ $status -ne 0 ]; then
   echo "\nTests failed. Aborting push." >&2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,5 +17,5 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-      - name: Run tests
-        run: pytest -q
+      - name: Run tests with coverage
+        run: pytest --cov=goal_glide --cov-report=term-missing --cov-fail-under=80 -q

--- a/README.md
+++ b/README.md
@@ -150,10 +150,10 @@ Run `python -m goal_glide config show` to view the current configuration.
 
 ## Running Tests
 
-To execute the unit tests run:
+To execute the unit tests with coverage run:
 
 ```bash
-pytest
+pytest --cov=goal_glide --cov-report=term-missing
 ```
 
 To run the test suite automatically before each push, configure Git to use the
@@ -163,8 +163,9 @@ included hooks directory:
 git config core.hooksPath .githooks
 ```
 
-With this option enabled, `pytest` and `mypy` will run whenever `git push`
-is invoked and the push will abort if either the tests or type checks fail.
+With this option enabled, the test suite will run with coverage and `mypy`
+whenever `git push` is invoked. The push will abort if tests, coverage
+(`--cov-fail-under=80`) or type checks fail.
 
 ## Pre-commit Hooks
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ click
 rich
 tinydb
 pytest
+pytest-cov
 apscheduler
 notify2
 textual>=0.55


### PR DESCRIPTION
## Summary
- run tests with coverage in pre-push hook
- enforce coverage in GitHub Actions
- document how to run coverage
- include pytest-cov in requirements

## Testing
- `pytest --cov=goal_glide --cov-report=term-missing --cov-fail-under=80 -q`

------
https://chatgpt.com/codex/tasks/task_e_6844ed223fb883228bd533bfe987ead2