### PR TITLE
Add test for string value in config

### DIFF
--- a/tests/test_config_module.py
+++ b/tests/test_config_module.py
@@ -94,3 +94,13 @@ def test_save_creates_parent_dirs(
     config.save_config({"quotes_enabled": False})
     assert nested.parent.exists() is True
     assert nested.exists() is True
+
+
+def test_save_string_value(cfg_path: Path) -> None:
+    cfg = {"foo": "bar"}
+    config.save_config(cfg)
+    config._CONFIG_CACHE = None
+    text = cfg_path.read_text()
+    assert "foo = 'bar'" in text
+    loaded = config.load_config()
+    assert loaded["foo"] == "bar"


### PR DESCRIPTION
## Summary
- cover saving string config values

## Testing
- `pytest -q tests/test_config_module.py::test_save_string_value`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844ed66af988322aca85f70d004bc19