### PR TITLE
Add docs directory with basic Sphinx setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ venv/
 *.swp
 *.swo
 
+docs/_build/

--- a/README.md
+++ b/README.md
@@ -180,5 +180,9 @@ pre-commit install
 The configured hook runs `black`, `flake8` and `mypy` on staged files so
 issues are caught early.
 
+## Documentation
+
+Sphinx configuration files live in the `docs` directory. Run `make html` inside that folder to build the HTML docs.
+
 ---
 Goal Glide is distributed under the terms of the GNU General Public License v3.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,7 @@
+SPHINXBUILD   = sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+.PHONY: html
+html:
+$(SPHINXBUILD) -M html $(SOURCEDIR) $(BUILDDIR)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,11 @@
+# Configuration file for the Sphinx documentation builder.
+
+project = 'Goal Glide'
+author = 'Goal Glide Developers'
+
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon']
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+html_theme = 'alabaster'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,11 @@
+Welcome to Goal Glide's documentation!
+=====================================
+
+This documentation is generated using Sphinx. To build the HTML pages run:
+
+.. code-block:: bash
+
+   cd docs
+   make html
+
+The built documentation will be available under ``_build/html``.

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ jinja2>=3.1
 pandas>=2.0
 mypy
 hypothesis
+sphinx


### PR DESCRIPTION
## Summary
- document how to build docs in README
- ignore built docs in `.gitignore`
- include Sphinx in `requirements.txt`
- add a minimal Sphinx configuration in `docs/`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844efc6cfa483228f4b825a9e943eca