### PR TITLE
Add thought removal command

### DIFF
--- a/goal_glide/cli.py
+++ b/goal_glide/cli.py
@@ -364,6 +364,7 @@ def list_thoughts_cmd(goal_id: str | None, limit: int) -> None:
     thoughts = storage.list_thoughts(goal_id=goal_id, limit=limit, newest_first=True)
 
     table = Table(title="Thoughts")
+    table.add_column("ID")
     table.add_column("When")
     table.add_column("Goal")
     table.add_column("Thought")
@@ -376,9 +377,21 @@ def list_thoughts_cmd(goal_id: str | None, limit: int) -> None:
                 goal_title = storage.get_goal(th.goal_id).title
             else:
                 goal_title = th.goal_id
-        table.add_row(when, goal_title, th.text)
+        table.add_row(th.id, when, goal_title, th.text)
 
     console.print(table)
+
+
+@thought.command("rm")
+@click.argument("thought_id")
+@handle_exceptions
+def remove_thought_cmd(thought_id: str) -> None:
+    """Delete a thought."""
+    storage = get_storage()
+    if storage.remove_thought(thought_id):
+        console.print(f"[green]Removed[/green] {thought_id}")
+    else:
+        console.print(f"[yellow]Thought {thought_id} not found[/yellow]")
 
 
 @goal.command("stats")

--- a/goal_glide/models/storage.py
+++ b/goal_glide/models/storage.py
@@ -209,3 +209,10 @@ class Storage:
         if limit is not None:
             rows = rows[:limit]
         return rows
+
+    def remove_thought(self, thought_id: str) -> bool:
+        """Delete a thought. Returns True if removed."""
+        if not self.thought_table.contains(Query().id == thought_id):
+            return False
+        self.thought_table.remove(Query().id == thought_id)
+        return True


### PR DESCRIPTION
## Summary
- add `remove_thought` method to storage
- show thought IDs when listing thoughts
- implement `thought rm` command
- test removing thoughts and missing-id message

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844b6245ae083228fbcab9224d99794