### PR TITLE
Add missing __main__ tests

### DIFF
--- a/tests/test_main_module.py
+++ b/tests/test_main_module.py
@@ -1,6 +1,17 @@
 import runpy
+import sys
+import types
 
 import pytest
+
+
+def _patch_cli(monkeypatch: pytest.MonkeyPatch, impl: callable) -> None:
+    """Inject a minimal ``goal_glide.cli`` module using *impl* as ``cli``."""
+
+    fake_cli_module = types.ModuleType("goal_glide.cli")
+    fake_cli_module.cli = impl
+    fake_cli_module.handle_exceptions = lambda func: func
+    monkeypatch.setitem(sys.modules, "goal_glide.cli", fake_cli_module)
 
 
 def test_main_invokes_cli(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -9,6 +20,26 @@ def test_main_invokes_cli(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_cli() -> None:
         called.append(True)
 
-    monkeypatch.setattr("goal_glide.cli.cli", fake_cli)
+    _patch_cli(monkeypatch, fake_cli)
     runpy.run_module("goal_glide.__main__", run_name="__main__")
     assert called == [True]
+
+
+def test_main_does_not_invoke_cli_when_not_main(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = []
+
+    def fake_cli() -> None:
+        called.append(True)
+
+    _patch_cli(monkeypatch, fake_cli)
+    runpy.run_module("goal_glide.__main__", run_name="not_main")
+    assert called == []
+
+
+def test_main_propagates_cli_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_cli() -> None:
+        raise RuntimeError("boom")
+
+    _patch_cli(monkeypatch, fake_cli)
+    with pytest.raises(RuntimeError):
+        runpy.run_module("goal_glide.__main__", run_name="__main__")

--- a/tests/test_main_module.py
+++ b/tests/test_main_module.py
@@ -2,15 +2,17 @@ import runpy
 import sys
 import types
 
+from typing import Callable
+
 import pytest
 
 
-def _patch_cli(monkeypatch: pytest.MonkeyPatch, impl: callable) -> None:
+def _patch_cli(monkeypatch: pytest.MonkeyPatch, impl: Callable[[], None]) -> None:
     """Inject a minimal ``goal_glide.cli`` module using *impl* as ``cli``."""
 
     fake_cli_module = types.ModuleType("goal_glide.cli")
-    fake_cli_module.cli = impl
-    fake_cli_module.handle_exceptions = lambda func: func
+    fake_cli_module.cli = impl  # type: ignore[attr-defined]
+    fake_cli_module.handle_exceptions = lambda func: func  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "goal_glide.cli", fake_cli_module)
 
 
@@ -25,7 +27,9 @@ def test_main_invokes_cli(monkeypatch: pytest.MonkeyPatch) -> None:
     assert called == [True]
 
 
-def test_main_does_not_invoke_cli_when_not_main(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_main_does_not_invoke_cli_when_not_main(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     called = []
 
     def fake_cli() -> None:


### PR DESCRIPTION
## Summary
- extend `tests/test_main_module.py` with helper to patch the CLI module
- add tests ensuring the CLI is only called when run as `__main__`
- verify exceptions from `cli()` propagate

## Testing
- `pytest tests/test_main_module.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f50b86408322af3a3dc7c2420bdf