### PR TITLE
Add pomodoro status command

### DIFF
--- a/goal_glide/cli.py
+++ b/goal_glide/cli.py
@@ -27,7 +27,7 @@ from .models.storage import Storage
 from .models.thought import Thought
 from .services import report
 from .services.analytics import current_streak, total_time_by_goal, weekly_histogram
-from .services.pomodoro import start_session, stop_session
+from .services.pomodoro import load_session, start_session, stop_session
 from .models.session import PomodoroSession
 from .services.quotes import get_random_quote
 from .services.render import render_goals
@@ -295,6 +295,19 @@ def stop_pomo() -> None:
         PomodoroSession.new(session.goal_id, session.start, session.duration_sec)
     )
     _print_completion(session)
+
+
+@pomo.command("status")
+@handle_exceptions
+def status_pomo() -> None:
+    """Show the remaining time for the current session."""
+    session = load_session()
+    if session is None:
+        console.print("No active session")
+        return
+    elapsed = int((datetime.now() - session.start).total_seconds())
+    remaining = max(session.duration_sec - elapsed, 0)
+    console.print(f"Elapsed {_fmt(elapsed)} | Remaining {_fmt(remaining)}")
 
 
 goal.add_command(pomo)

--- a/tests/test_pomo_status.py
+++ b/tests/test_pomo_status.py
@@ -1,0 +1,46 @@
+import datetime
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from goal_glide import cli
+from goal_glide.services import pomodoro
+
+
+def test_status_no_session(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
+    pomodoro.POMO_PATH = tmp_path / "session.json"
+    runner = CliRunner()
+    result = runner.invoke(cli.goal, ["pomo", "status"])
+    assert result.exit_code == 0
+    assert "No active session" in result.output
+
+
+def test_status_with_session(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
+    pomodoro.POMO_PATH = tmp_path / "session.json"
+    start_time = datetime.datetime(2023, 1, 1, 12, 0, 0)
+
+    class StartDT(datetime.datetime):
+        @classmethod
+        def now(cls) -> datetime.datetime:  # type: ignore[override]
+            return start_time
+
+    monkeypatch.setattr(pomodoro, "datetime", StartDT)
+    pomodoro.start_session(30)
+
+    later = start_time + datetime.timedelta(minutes=10)
+
+    class LaterDT(datetime.datetime):
+        @classmethod
+        def now(cls) -> datetime.datetime:  # type: ignore[override]
+            return later
+
+    monkeypatch.setattr(cli, "datetime", LaterDT)
+    runner = CliRunner()
+    result = runner.invoke(cli.goal, ["pomo", "status"])
+    assert result.exit_code == 0
+    assert "Elapsed 10m" in result.output
+    assert "Remaining 20m" in result.output


### PR DESCRIPTION
## Summary
- extend CLI with `pomo status`
- print elapsed and remaining time for current pomodoro
- show message when no session active
- test pomodoro status scenarios

## Testing
- `flake8 goal_glide/cli.py tests/test_pomo_status.py`
- `mypy goal_glide/cli.py tests/test_pomo_status.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f703007c83228e385c3d712c76d4