### PR TITLE
Add migration tags test

### DIFF
--- a/tests/test_migration_tags.py
+++ b/tests/test_migration_tags.py
@@ -16,3 +16,21 @@ def test_migrate_adds_empty_tags(tmp_path: Path) -> None:
     storage = Storage(tmp_path)
     goal = storage.get_goal("g1")
     assert goal.tags == []
+
+
+def test_migrate_keeps_existing_tags(tmp_path: Path) -> None:
+    db_path = tmp_path / "db.json"
+    db = TinyDB(db_path)
+    goals = db.table("goals")
+    goals.insert(
+        {
+            "id": "g1",
+            "title": "t",
+            "created": datetime.now().isoformat(),
+            "tags": ["a"],
+        }
+    )
+
+    storage = Storage(tmp_path)
+    goal = storage.get_goal("g1")
+    assert goal.tags == ["a"]


### PR DESCRIPTION
## Summary
- ensure tags are preserved when migrating goals

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f92084c88322adc4176c56fdd5a7