### PR TITLE
Update migration test for tags

### DIFF
--- a/tests/test_migration_tags.py
+++ b/tests/test_migration_tags.py
@@ -7,30 +7,17 @@ from goal_glide.models.storage import Storage
 from tinydb import TinyDB
 
 
-def test_migrate_adds_empty_tags(tmp_path: Path) -> None:
+def test_tags_migration(tmp_path: Path) -> None:
     db_path = tmp_path / "db.json"
     db = TinyDB(db_path)
     goals = db.table("goals")
-    goals.insert({"id": "g1", "title": "t", "created": datetime.now().isoformat()})
+    goals.insert({"id": "g1", "title": "t1", "created": datetime.now().isoformat()})
+    goals.insert({"id": "g2", "title": "t2", "created": datetime.now().isoformat(), "tags": ["t"]})
 
     storage = Storage(tmp_path)
-    goal = storage.get_goal("g1")
-    assert goal.tags == []
+    goal1 = storage.get_goal("g1")
+    goal2 = storage.get_goal("g2")
 
+    assert goal1.tags == []
+    assert goal2.tags == ["t"]
 
-def test_migrate_keeps_existing_tags(tmp_path: Path) -> None:
-    db_path = tmp_path / "db.json"
-    db = TinyDB(db_path)
-    goals = db.table("goals")
-    goals.insert(
-        {
-            "id": "g1",
-            "title": "t",
-            "created": datetime.now().isoformat(),
-            "tags": ["a"],
-        }
-    )
-
-    storage = Storage(tmp_path)
-    goal = storage.get_goal("g1")
-    assert goal.tags == ["a"]

--- a/tests/test_migration_tags.py
+++ b/tests/test_migration_tags.py
@@ -12,7 +12,14 @@ def test_tags_migration(tmp_path: Path) -> None:
     db = TinyDB(db_path)
     goals = db.table("goals")
     goals.insert({"id": "g1", "title": "t1", "created": datetime.now().isoformat()})
-    goals.insert({"id": "g2", "title": "t2", "created": datetime.now().isoformat(), "tags": ["t"]})
+    goals.insert(
+        {
+            "id": "g2",
+            "title": "t2",
+            "created": datetime.now().isoformat(),
+            "tags": ["t"],
+        }
+    )
 
     storage = Storage(tmp_path)
     goal1 = storage.get_goal("g1")
@@ -20,4 +27,3 @@ def test_tags_migration(tmp_path: Path) -> None:
 
     assert goal1.tags == []
     assert goal2.tags == ["t"]
-


### PR DESCRIPTION
## Summary
- consolidate migration test for tags
- verify both legacy and tagged goals after Storage initialization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844fa47b9308322b80c6bae9b084c44