### PR TITLE
Add test for tags migration update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ venv/
 
 # pytest cache
 .pytest_cache/
+.hypothesis/
 
 # Editors
 *.swp

--- a/tests/test_migration_tags.py
+++ b/tests/test_migration_tags.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from pathlib import Path
 
 from goal_glide.models.storage import Storage
-from tinydb import TinyDB
+from tinydb import Query, TinyDB
 
 
 def test_tags_migration(tmp_path: Path) -> None:
@@ -27,3 +27,16 @@ def test_tags_migration(tmp_path: Path) -> None:
 
     assert goal1.tags == []
     assert goal2.tags == ["t"]
+
+
+def test_tags_migration_updates_db(tmp_path: Path) -> None:
+    """Verify migration writes missing tags back to the DB file."""
+    db_path = tmp_path / "db.json"
+    db = TinyDB(db_path)
+    db.table("goals").insert({"id": "g1", "title": "t1", "created": datetime.now().isoformat()})
+
+    storage = Storage(tmp_path)
+
+    db2 = TinyDB(db_path)
+    row = db2.table("goals").get(Query().id == "g1")
+    assert row["tags"] == []


### PR DESCRIPTION
## Summary
- ensure migrating tags writes to db file
- ignore Hypothesis cache

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844fc34116c83229bd1740a9c3599db