### PR TITLE
Add Codecov upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,4 +19,10 @@ jobs:
           pip install poetry
           poetry install --no-interaction --no-root
       - name: Run tests with coverage
-        run: poetry run pytest --cov=goal_glide --cov-report=term-missing --cov-fail-under=80 -q
+        run: poetry run pytest --cov=goal_glide --cov-report=term-missing --cov-report=xml --cov-fail-under=80 -q
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+          fail_ci_if_error: true


### PR DESCRIPTION
## Summary
- add Codecov coverage upload step in test workflow

## Testing
- `flake8`
- `poetry run mypy goal_glide`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684506a4488c8322bfb76779c6cdc6e5