### PR TITLE
Add test for PomodoroSession without goal

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -50,6 +50,12 @@ def test_session_new_unique_ids(monkeypatch: pytest.MonkeyPatch) -> None:
     assert s1.id != s2.id
 
 
+def test_session_new_without_goal_generates_id() -> None:
+    s = PomodoroSession.new(None, datetime.utcnow(), 60)
+    assert s.goal_id is None
+    assert isinstance(s.id, str) and len(s.id) > 0
+
+
 def test_thought_new_trims() -> None:
     t = Thought.new(" text ", None)
     assert t.text == "text"


### PR DESCRIPTION
## Summary
- add coverage for PomodoroSession.new when goal_id is `None`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68450b36abcc832293b6dd59fbfe9552