### PR TITLE
Add subgoal listing tests

### DIFF
--- a/tests/test_goal_subgoals.py
+++ b/tests/test_goal_subgoals.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from pathlib import Path
+import tempfile
 
 from goal_glide.models.goal import Goal
 from goal_glide.models.storage import Storage
@@ -27,3 +28,90 @@ def test_list_goals_parent_filter(tmp_path: Path) -> None:
 
     children = storage.list_goals(parent_id="p")
     assert {g.id for g in children} == {"c1", "c2"}
+
+
+def test_remove_parent_keeps_children(tmp_path: Path) -> None:
+    storage = Storage(tmp_path)
+    parent = Goal(id="p", title="p", created=datetime.utcnow())
+    c1 = Goal(id="c1", title="c1", created=datetime.utcnow(), parent_id="p")
+    c2 = Goal(id="c2", title="c2", created=datetime.utcnow(), parent_id="p")
+    storage.add_goal(parent)
+    storage.add_goal(c1)
+    storage.add_goal(c2)
+
+    storage.remove_goal("p")
+
+    assert storage.get_goal("c1").parent_id == "p"
+    assert storage.get_goal("c2").parent_id == "p"
+    children = storage.list_goals(parent_id="p")
+    assert {g.id for g in children} == {"c1", "c2"}
+
+
+def test_list_goals_parent_with_archived_flags(tmp_path: Path) -> None:
+    storage = Storage(tmp_path)
+    p = Goal(id="p", title="parent", created=datetime.utcnow())
+    active = Goal(id="a", title="active", created=datetime.utcnow(), parent_id="p")
+    archived = Goal(id="b", title="archived", created=datetime.utcnow(), parent_id="p")
+    storage.add_goal(p)
+    storage.add_goal(active)
+    storage.add_goal(archived)
+    storage.archive_goal("b")
+
+    listed = storage.list_goals(parent_id="p")
+    assert [g.id for g in listed] == ["a"]
+
+    listed = storage.list_goals(parent_id="p", include_archived=True)
+    assert {g.id for g in listed} == {"a", "b"}
+
+    listed = storage.list_goals(parent_id="p", only_archived=True)
+    assert [g.id for g in listed] == ["b"]
+
+
+def test_list_goals_parent_missing_returns_empty(tmp_path: Path) -> None:
+    storage = Storage(tmp_path)
+    storage.add_goal(Goal(id="p", title="parent", created=datetime.utcnow()))
+    storage.add_goal(
+        Goal(id="c", title="child", created=datetime.utcnow(), parent_id="p")
+    )
+
+    assert storage.list_goals(parent_id="missing") == []
+
+
+from hypothesis import given, settings, strategies as st
+
+
+@st.composite
+def _parent_child_mapping(draw: st.DrawFn) -> dict[str, list[str]]:
+    parents = draw(
+        st.lists(st.text(min_size=1, max_size=3), unique=True, min_size=1, max_size=5)
+    )
+    all_children = draw(
+        st.lists(st.text(min_size=1, max_size=3), unique=True, max_size=10)
+    )
+    mapping = {p: [] for p in parents}
+    for cid in all_children:
+        parent = draw(st.sampled_from(parents))
+        mapping[parent].append(cid)
+    return mapping
+
+
+@given(_parent_child_mapping())
+@settings(max_examples=25)
+def test_list_goals_parent_property(mapping: dict[str, list[str]]) -> None:
+    with tempfile.TemporaryDirectory() as d:
+        storage = Storage(Path(d))
+        for pid in mapping:
+            storage.add_goal(Goal(id=pid, title=pid, created=datetime.utcnow()))
+        for pid, cids in mapping.items():
+            for cid in cids:
+                storage.add_goal(
+                    Goal(
+                        id=cid,
+                        title=cid,
+                        created=datetime.utcnow(),
+                        parent_id=pid,
+                    )
+                )
+        for pid, cids in mapping.items():
+            listed = storage.list_goals(parent_id=pid)
+            assert {g.id for g in listed} == set(cids)


### PR DESCRIPTION
## Summary
- expand `test_goal_subgoals` coverage
  - ensure deleting a parent doesn't remove children
  - verify archived flag filtering for subgoal listing
  - check parent filter with nonexistent ID
  - property test for consistent parent-child listing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68450e0eafe8832284b115f4c8c36b1f