### PR TITLE
Add quote fallback tests

### DIFF
--- a/tests/test_pomo_quotes.py
+++ b/tests/test_pomo_quotes.py
@@ -43,3 +43,61 @@ def test_quotes_disabled(
     result = runner.invoke(cli.goal, ["pomo", "stop"])
     assert "Pomodoro complete" in result.output
     assert "Q" not in result.output
+
+
+def test_quote_fallback(monkeypatch: pytest.MonkeyPatch, runner: CliRunner) -> None:
+    monkeypatch.setattr(
+        quotes.requests,
+        "get",
+        lambda *a, **k: (_ for _ in ()).throw(quotes.requests.RequestException()),
+    )
+    monkeypatch.setattr(quotes, "_LOCAL_CACHE", None)
+    monkeypatch.setattr(quotes.random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(cli, "get_random_quote", quotes.get_random_quote)
+    runner.invoke(cli.goal, ["pomo", "start", "--duration", "1"])
+    result = runner.invoke(cli.goal, ["pomo", "stop"])
+    assert "Inspirational quote 1" in result.output
+
+
+def test_quote_exception_handling(
+    monkeypatch: pytest.MonkeyPatch, runner: CliRunner
+) -> None:
+    def boom(use_online: bool = True) -> tuple[str, str]:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(quotes, "get_random_quote", boom)
+    monkeypatch.setattr(cli, "get_random_quote", boom)
+    runner.invoke(cli.goal, ["pomo", "start", "--duration", "1"])
+    result = runner.invoke(cli.goal, ["pomo", "stop"])
+    assert result.exit_code == 1
+    assert "Error:" in result.output
+
+
+def test_quotes_default_enabled(
+    monkeypatch: pytest.MonkeyPatch, runner: CliRunner
+) -> None:
+    result = runner.invoke(cli.goal, ["config", "quotes"])
+    assert result.exit_code == 0
+    assert "Quotes are ON" in result.output
+
+
+def test_quotes_disabled_no_call(
+    monkeypatch: pytest.MonkeyPatch, runner: CliRunner, tmp_path: Path
+) -> None:
+    path = tmp_path / ".goal_glide" / "config.toml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("quotes_enabled = false", encoding="utf-8")
+    cfg._CONFIG_CACHE = None
+    called: list[bool] = []
+
+    def fake(use_online: bool = True) -> tuple[str, str]:
+        called.append(True)
+        return ("Q", "A")
+
+    monkeypatch.setattr(quotes, "get_random_quote", fake)
+    monkeypatch.setattr(cli, "get_random_quote", fake)
+    runner.invoke(cli.goal, ["pomo", "start", "--duration", "1"])
+    result = runner.invoke(cli.goal, ["pomo", "stop"])
+    assert called == []
+    assert "Pomodoro complete" in result.output
+    assert "Q" not in result.output


### PR DESCRIPTION
## Summary
- expand pomodoro quote tests
- add fallback and exception handling tests
- verify default quote setting via CLI
- ensure quote service is not called when disabled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68451109138483229b94b69a09a325e7