### PR TITLE
Add custom date range filtering for stats and reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ python -m goal_glide stats
 ```
 
 Use `--month` for the last month and `--goals` to show totals for top goals.
+Custom ranges can be specified with `--from` and `--to` using `YYYY-MM-DD` dates.
 
 ### TUI
 
@@ -184,7 +185,8 @@ Quick examples of common commands:
   ```bash
   python -m goal_glide reminder status
   ```
-- **stats** – view weekly or monthly focus history.
+- **stats** – view focus history. Use `--month` for the last month or specify
+  a custom range with `--from` and `--to`.
   ```bash
   python -m goal_glide stats --month
   ```
@@ -192,6 +194,7 @@ Quick examples of common commands:
   ```bash
   python -m goal_glide report make --week
   ```
+  Use `--from` and `--to` to generate a report for a custom date range.
 
 ## Reports
 
@@ -199,6 +202,8 @@ Generate a summary of your sessions and goals with:
 
 ```bash
 python -m goal_glide report make --week|--month|--all --format [html|md|csv] --out ~/reports/progress.html
+# or specify a custom range
+python -m goal_glide report make --from 2023-01-01 --to 2023-01-31 --format html --out ~/reports/january.html
 ```
 
 The HTML and Markdown templates used for report generation live in `goal_glide/templates/`.

--- a/goal_glide/cli.py
+++ b/goal_glide/cli.py
@@ -29,7 +29,6 @@ from .services import report
 from .services.analytics import (
     current_streak,
     total_time_by_goal,
-    weekly_histogram,
     date_histogram,
 )
 from .services.pomodoro import load_session, start_session, stop_session

--- a/goal_glide/services/analytics.py
+++ b/goal_glide/services/analytics.py
@@ -7,30 +7,48 @@ from typing import Dict
 from ..models.session import PomodoroSession
 from ..models.storage import Storage
 
-__all__ = ["total_time_by_goal", "weekly_histogram", "current_streak"]
+__all__ = [
+    "total_time_by_goal",
+    "weekly_histogram",
+    "current_streak",
+    "date_histogram",
+]
 
 
 def _all_sessions(storage: Storage) -> list[PomodoroSession]:
     return storage.list_sessions()
 
 
-def total_time_by_goal(storage: Storage) -> Dict[str, int]:
+def total_time_by_goal(
+    storage: Storage, start: date | None = None, end: date | None = None
+) -> Dict[str, int]:
     acc: Dict[str, int] = defaultdict(int)
     for s in _all_sessions(storage):
         if s.duration_sec and s.goal_id is not None:
+            day = s.start.date()
+            if start and day < start:
+                continue
+            if end and day > end:
+                continue
             acc[s.goal_id] += s.duration_sec
     return dict(acc)
 
 
-def weekly_histogram(storage: Storage, start: date) -> Dict[date, int]:
-    buckets: Dict[date, int] = {start + timedelta(days=i): 0 for i in range(7)}
+def date_histogram(storage: Storage, start: date, end: date) -> Dict[date, int]:
+    buckets: Dict[date, int] = {
+        start + timedelta(days=i): 0 for i in range((end - start).days + 1)
+    }
     for s in _all_sessions(storage):
         if not s.duration_sec:
             continue
         bucket_day = s.start.date()
-        if start <= bucket_day <= start + timedelta(days=6):
+        if start <= bucket_day <= end:
             buckets[bucket_day] += s.duration_sec
     return buckets
+
+
+def weekly_histogram(storage: Storage, start: date) -> Dict[date, int]:
+    return date_histogram(storage, start, start + timedelta(days=6))
 
 
 def current_streak(storage: Storage, today: date | None = None) -> int:

--- a/tests/test_report_cli.py
+++ b/tests/test_report_cli.py
@@ -54,3 +54,28 @@ def test_cli_flag_collision(runner: CliRunner) -> None:
     result = runner.invoke(cli.goal, ["report", "make", "--week", "--month"])
     assert result.exit_code != 0
     assert "only one" in result.output
+
+
+def test_cli_custom_range(
+    tmp_path: Path, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(report, "date", FakeDate)
+    storage = Storage(tmp_path)
+    seed(storage)
+    out = tmp_path / "range.html"
+    result = runner.invoke(
+        cli.goal,
+        [
+            "report",
+            "make",
+            "--from",
+            "2023-06-01",
+            "--to",
+            "2023-06-14",
+            "--out",
+            str(out),
+        ],
+        env={"GOAL_GLIDE_DB_DIR": str(tmp_path)},
+    )
+    assert result.exit_code == 0
+    assert out.exists()


### PR DESCRIPTION
## Summary
- add `date_histogram` and range support in analytics helpers
- update report building to accept custom date ranges
- extend CLI `stats` and `report make` commands with `--from/--to`
- document date range options in README
- test custom range behavior for stats and report commands

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68451232035083229e9e872f5724fe34