### PR TITLE
Add pomodoro pause and resume commands

### DIFF
--- a/goal_glide/cli.py
+++ b/goal_glide/cli.py
@@ -31,7 +31,14 @@ from .services.analytics import (
     total_time_by_goal,
     date_histogram,
 )
-from .services.pomodoro import load_session, start_session, stop_session
+from .services.pomodoro import (
+    load_active_session,
+    load_session,
+    pause_session,
+    resume_session,
+    start_session,
+    stop_session,
+)
 from .models.session import PomodoroSession
 from .services.quotes import get_random_quote
 from .services.render import render_goals
@@ -320,15 +327,31 @@ def stop_pomo(ctx: click.Context) -> None:
     _print_completion(session)
 
 
+@pomo.command("pause")
+@handle_exceptions
+def pause_pomo() -> None:
+    pause_session()
+    console.print("Session paused")
+
+
+@pomo.command("resume")
+@handle_exceptions
+def resume_pomo() -> None:
+    resume_session()
+    console.print("Session resumed")
+
+
 @pomo.command("status")
 @handle_exceptions
 def status_pomo() -> None:
     """Show the remaining time for the current session."""
-    session = load_session()
+    session = load_active_session()
     if session is None:
         console.print("No active session")
         return
-    elapsed = int((datetime.now() - session.start).total_seconds())
+    elapsed = session.elapsed_sec
+    if not session.paused and session.last_start is not None:
+        elapsed += int((datetime.now() - session.last_start).total_seconds())
     remaining = max(session.duration_sec - elapsed, 0)
     console.print(f"Elapsed {_fmt(elapsed)} | Remaining {_fmt(remaining)}")
 

--- a/goal_glide/services/pomodoro.py
+++ b/goal_glide/services/pomodoro.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Callable, Optional
@@ -18,6 +19,34 @@ on_session_end: list[Callable[[], None]] = []
 POMO_PATH = Path.home() / ".goal_glide" / "session.json"
 
 
+@dataclass(slots=True)
+class ActiveSession:
+    goal_id: str | None
+    start: datetime
+    duration_sec: int
+    elapsed_sec: int
+    paused: bool
+    last_start: datetime | None
+
+
+def _load_data() -> dict | None:
+    if not POMO_PATH.exists():
+        return None
+    with POMO_PATH.open(encoding="utf-8") as fp:
+        data = json.load(fp)
+    # backward compatibility for older session files
+    data.setdefault("elapsed_sec", 0)
+    data.setdefault("paused", False)
+    data.setdefault("last_start", data.get("start"))
+    return data
+
+
+def _save_data(data: dict) -> None:
+    POMO_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with POMO_PATH.open("w", encoding="utf-8") as fp:
+        json.dump(data, fp)
+
+
 def start_session(
     duration_min: int = 25,
     goal_id: str | None = None,
@@ -28,26 +57,24 @@ def start_session(
         start=datetime.now(),
         duration_sec=duration_min * 60,
     )
-    POMO_PATH.parent.mkdir(parents=True, exist_ok=True)
-    with POMO_PATH.open("w", encoding="utf-8") as fp:
-        json.dump(
-            {
-                "start": session.start.isoformat(),
-                "duration_sec": session.duration_sec,
-                "goal_id": session.goal_id,
-            },
-            fp,
-        )
+    data = {
+        "start": session.start.isoformat(),
+        "duration_sec": session.duration_sec,
+        "goal_id": session.goal_id,
+        "elapsed_sec": 0,
+        "paused": False,
+        "last_start": session.start.isoformat(),
+    }
+    _save_data(data)
     for cb in on_new_session:
         cb()
     return session
 
 
 def load_session() -> Optional[PomodoroSession]:
-    if not POMO_PATH.exists():
+    data = _load_data()
+    if data is None:
         return None
-    with POMO_PATH.open(encoding="utf-8") as fp:
-        data = json.load(fp)
     return PomodoroSession(
         id="",
         goal_id=data.get("goal_id"),
@@ -56,13 +83,74 @@ def load_session() -> Optional[PomodoroSession]:
     )
 
 
+def load_active_session() -> Optional[ActiveSession]:
+    data = _load_data()
+    if data is None:
+        return None
+    last_start = (
+        datetime.fromisoformat(data["last_start"])
+        if data.get("last_start")
+        else None
+    )
+    return ActiveSession(
+        goal_id=data.get("goal_id"),
+        start=datetime.fromisoformat(data["start"]),
+        duration_sec=data["duration_sec"],
+        elapsed_sec=data.get("elapsed_sec", 0),
+        paused=data.get("paused", False),
+        last_start=last_start,
+    )
+
+
 def stop_session() -> PomodoroSession:
-    session = load_session()
-    if session is None:
+    active = load_active_session()
+    if active is None:
         raise RuntimeError("No active session")
+    # update elapsed if still running
+    if not active.paused and active.last_start is not None:
+        now = datetime.now()
+        delta = int((now - active.last_start).total_seconds())
+        data = _load_data() or {}
+        data["elapsed_sec"] = active.elapsed_sec + delta
+        _save_data(data)
     POMO_PATH.unlink(missing_ok=True)
     for cb in on_session_end:
         cb()
     if config.reminders_enabled():
         console.print(":bell:  Break & interval reminders scheduled.", style="green")
-    return session
+    return PomodoroSession(
+        id="",
+        goal_id=active.goal_id,
+        start=active.start,
+        duration_sec=active.duration_sec,
+    )
+
+
+def pause_session() -> ActiveSession:
+    active = load_active_session()
+    if active is None:
+        raise RuntimeError("No active session")
+    if active.paused:
+        raise RuntimeError("Session already paused")
+    now = datetime.now()
+    delta = int((now - active.last_start).total_seconds()) if active.last_start else 0
+    data = _load_data() or {}
+    data["elapsed_sec"] = active.elapsed_sec + delta
+    data["paused"] = True
+    data["last_start"] = None
+    _save_data(data)
+    return load_active_session()  # type: ignore[return-value]
+
+
+def resume_session() -> ActiveSession:
+    active = load_active_session()
+    if active is None:
+        raise RuntimeError("No active session")
+    if not active.paused:
+        raise RuntimeError("Session is not paused")
+    now = datetime.now()
+    data = _load_data() or {}
+    data["paused"] = False
+    data["last_start"] = now.isoformat()
+    _save_data(data)
+    return load_active_session()  # type: ignore[return-value]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,6 +54,20 @@ def test_pomo_session_persisted(tmp_path, monkeypatch):
     assert sessions[0].goal_id == gid
 
 
+def test_pomo_pause_resume(tmp_path, monkeypatch):
+    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    pomodoro.POMO_PATH = tmp_path / "session.json"
+    runner = CliRunner()
+    runner.invoke(cli.goal, ["pomo", "start", "--duration", "1"])
+    res = runner.invoke(cli.goal, ["pomo", "pause"])
+    assert res.exit_code == 0
+    assert "paused" in res.output.lower()
+    res = runner.invoke(cli.goal, ["pomo", "resume"])
+    assert res.exit_code == 0
+    assert "resumed" in res.output.lower()
+
+
 def test_jot_from_editor(tmp_path, monkeypatch):
     monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
     monkeypatch.setattr(click, "edit", lambda *a, **k: "note from editor\n")
@@ -83,3 +97,4 @@ def test_config_quotes_enable(tmp_path, monkeypatch):
     assert result.exit_code == 0
     assert "Quotes are ON" in result.output
     assert config.quotes_enabled() is True
+

--- a/tests/test_pomo_status.py
+++ b/tests/test_pomo_status.py
@@ -44,3 +44,37 @@ def test_status_with_session(tmp_path: Path, monkeypatch):
     assert result.exit_code == 0
     assert "Elapsed 10m" in result.output
     assert "Remaining 20m" in result.output
+
+
+def test_status_paused(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
+    pomodoro.POMO_PATH = tmp_path / "session.json"
+    start_time = datetime.datetime(2023, 1, 1, 12, 0, 0)
+
+    class StartDT(datetime.datetime):
+        @classmethod
+        def now(cls) -> datetime.datetime:  # type: ignore[override]
+            return start_time
+
+    monkeypatch.setattr(pomodoro, "datetime", StartDT)
+    pomodoro.start_session(30)
+
+    later = start_time + datetime.timedelta(minutes=10)
+    monkeypatch.setattr(pomodoro, "datetime", type("DT", (datetime.datetime,), {"now": classmethod(lambda cls: later)}))
+    pomodoro.pause_session()
+
+    much_later = start_time + datetime.timedelta(minutes=20)
+
+    class LaterDT(datetime.datetime):
+        @classmethod
+        def now(cls) -> datetime.datetime:  # type: ignore[override]
+            return much_later
+
+    monkeypatch.setattr(cli, "datetime", LaterDT)
+    runner = CliRunner()
+    result = runner.invoke(cli.goal, ["pomo", "status"])
+    assert result.exit_code == 0
+    assert "Elapsed 10m" in result.output
+    assert "Remaining 20m" in result.output
+

--- a/tests/test_pomodoro_service.py
+++ b/tests/test_pomodoro_service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -64,3 +64,27 @@ def test_stop_session_deletes_file(
 def test_stop_session_no_file_raises(session_path: Path) -> None:
     with pytest.raises(RuntimeError):
         pomodoro.stop_session()
+
+
+def test_pause_resume_flow(monkeypatch: pytest.MonkeyPatch, session_path: Path) -> None:
+    start = datetime(2023, 1, 2, 9, 0, 0)
+    _patch_now(monkeypatch, start)
+    pomodoro.start_session(10)
+
+    five = start + timedelta(minutes=5)
+    _patch_now(monkeypatch, five)
+    paused = pomodoro.pause_session()
+    assert paused.paused is True
+    data = json.loads(session_path.read_text())
+    assert data["elapsed_sec"] == 300
+
+    seven = start + timedelta(minutes=7)
+    _patch_now(monkeypatch, seven)
+    resumed = pomodoro.resume_session()
+    assert resumed.paused is False
+    assert json.loads(session_path.read_text())["elapsed_sec"] == 300
+
+    twelve = start + timedelta(minutes=12)
+    _patch_now(monkeypatch, twelve)
+    pomodoro.stop_session()
+


### PR DESCRIPTION
## Summary
- support pausing and resuming pomodoro sessions
- update session tracking logic for paused state
- add CLI commands `pomo pause` and `pomo resume`
- test pause/resume behavior in service, CLI and status reporting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845186860c883229a455ef8ca9b69e4