### PR TITLE
Add Hypothesis-based reminder scheduling test

### DIFF
--- a/tests/test_pomo_reminder_flow.py
+++ b/tests/test_pomo_reminder_flow.py
@@ -9,13 +9,15 @@ from click.testing import CliRunner
 from goal_glide import cli
 from goal_glide import config as cfg
 from goal_glide.services import notify, reminder, pomodoro
+from hypothesis import HealthCheck, given, settings, strategies as st
+from typing import Callable
 
 FIXED_NOW = datetime(2024, 1, 1, 12, 0, 0)
 
 
 class FakeScheduler:
     def __init__(self) -> None:
-        self.jobs: list[tuple[callable, tuple, dict]] = []
+        self.jobs: list[tuple[Callable, tuple, dict]] = []
 
     def add_job(self, func, _trigger, **kwargs) -> None:
         self.jobs.append((func, kwargs.get("args", ()), kwargs))
@@ -55,8 +57,9 @@ def test_flow_schedules_jobs(runner) -> None:
     result = cli_runner.invoke(cli.goal, ["pomo", "stop"])
     assert "reminders scheduled" in result.output
     sched = reminder._sched
-    assert len(sched.jobs) == 2
-    for func, args, _ in sched.jobs:
+    assert sched is not None
+    assert len(sched.jobs) == 2  # type: ignore[attr-defined]
+    for func, args, _ in sched.jobs:  # type: ignore[attr-defined]
         func(*args)
     assert any("Pomodoro" in m or "Break" in m for m in messages)
 
@@ -71,9 +74,10 @@ def test_flow_uses_config_and_clears_existing_jobs(runner) -> None:
     reminder.schedule_after_stop()
     reminder.schedule_after_stop()
     sched = reminder._sched
-    assert len(sched.jobs) == 2
-    first_kwargs = sched.jobs[0][2]
-    second_kwargs = sched.jobs[1][2]
+    assert sched is not None
+    assert len(sched.jobs) == 2  # type: ignore[attr-defined]
+    first_kwargs = sched.jobs[0][2]  # type: ignore[attr-defined]
+    second_kwargs = sched.jobs[1][2]  # type: ignore[attr-defined]
     assert first_kwargs["run_date"] == FIXED_NOW + timedelta(minutes=2)
     assert second_kwargs["minutes"] == 7
 
@@ -81,13 +85,39 @@ def test_flow_uses_config_and_clears_existing_jobs(runner) -> None:
 def test_cancel_all_runs_on_new_session(runner, monkeypatch, tmp_path) -> None:
     cli_runner, _ = runner
     sched = reminder._sched
+    assert sched is not None
     # pre-populate fake scheduler with dummy jobs
-    sched.add_job(lambda: None, "interval")
-    sched.add_job(lambda: None, "interval")
-    assert len(sched.jobs) == 2
+    sched.add_job(lambda: None, "interval")  # type: ignore[attr-defined]
+    sched.add_job(lambda: None, "interval")  # type: ignore[attr-defined]
+    assert len(sched.jobs) == 2  # type: ignore[attr-defined]
 
     monkeypatch.setattr(pomodoro, "POMO_PATH", tmp_path / "session.json")
 
     pomodoro.start_session(1)
 
-    assert sched.jobs == []
+    assert sched.jobs == []  # type: ignore[attr-defined]
+
+
+@given(
+    break_min=st.integers(min_value=1, max_value=120),
+    interval_min=st.integers(min_value=1, max_value=120),
+)
+@settings(max_examples=10, suppress_health_check=[HealthCheck.function_scoped_fixture])
+def test_schedule_after_stop_randomized(
+    runner, monkeypatch, break_min: int, interval_min: int
+) -> None:
+    """`schedule_after_stop` uses config values when scheduling."""
+    _, _ = runner
+    monkeypatch.setattr(reminder, "reminders_enabled", lambda: True)
+    monkeypatch.setattr(reminder, "reminder_break", lambda: break_min)
+    monkeypatch.setattr(reminder, "reminder_interval", lambda: interval_min)
+
+    reminder.schedule_after_stop()
+
+    sched = reminder._sched
+    assert sched is not None
+    assert len(sched.jobs) == 2  # type: ignore[attr-defined]
+    first_kwargs = sched.jobs[0][2]  # type: ignore[attr-defined]
+    second_kwargs = sched.jobs[1][2]  # type: ignore[attr-defined]
+    assert first_kwargs["run_date"] == FIXED_NOW + timedelta(minutes=break_min)
+    assert second_kwargs["minutes"] == interval_min


### PR DESCRIPTION
## Summary
- add new property test `test_schedule_after_stop_randomized`
- import Hypothesis helpers and add mypy fixes
- ensure FakeScheduler typing passes mypy

## Testing
- `pre-commit run --files tests/test_pomo_reminder_flow.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684519da1b488322a5c2fcbf60421df6