### PR TITLE
Improve storage filtering using TinyDB queries

### DIFF
--- a/goal_glide/models/storage.py
+++ b/goal_glide/models/storage.py
@@ -177,7 +177,7 @@ class Storage:
         predicates = []
 
         if only_archived:
-            predicates.append(GoalQuery.archived == True)
+            predicates.append(lambda r: r.get("archived") is True)
         elif not include_archived:
             predicates.append(lambda r: not r.get("archived", False))
 


### PR DESCRIPTION
## Summary
- use TinyDB's `search` to filter goals
- use `search` when listing thoughts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68451e4a98288322ab90f9f9685ab19a