### PR TITLE
Implement sub-goal hierarchy

### DIFF
--- a/goal_glide/services/analytics.py
+++ b/goal_glide/services/analytics.py
@@ -34,6 +34,14 @@ def total_time_by_goal(
             if end and day > end:
                 continue
             acc[s.goal_id] += s.duration_sec
+
+    goals = {g.id: g for g in storage.list_goals(include_archived=True)}
+    for gid, total in list(acc.items()):
+        g = goals.get(gid)
+        while g and g.parent_id:
+            acc[g.parent_id] += total
+            g = goals.get(g.parent_id)
+
     return dict(acc)
 
 

--- a/goal_glide/tui.py
+++ b/goal_glide/tui.py
@@ -12,7 +12,8 @@ if "" in sys.path:
 
 from textual.app import App, ComposeResult
 from textual.reactive import reactive
-from textual.widgets import Tree, TreeNode, Footer, Header, Static
+from textual.widgets import Tree, Footer, Header, Static
+from textual.widgets.tree import TreeNode
 
 from .cli import get_storage
 from .models.goal import Goal, Priority

--- a/goal_glide/tui.py
+++ b/goal_glide/tui.py
@@ -11,9 +11,8 @@ if "" in sys.path:
     sys.path.append("")
 
 from textual.app import App, ComposeResult
-from textual.coordinate import Coordinate
 from textual.reactive import reactive
-from textual.widgets import DataTable, Footer, Header, Static
+from textual.widgets import Tree, TreeNode, Footer, Header, Static
 
 from .cli import get_storage
 from .models.goal import Goal, Priority
@@ -44,32 +43,45 @@ class GoalGlideApp(App[None]):
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
-        yield DataTable(id="goal_table")
+        yield Tree("Goals", id="goal_tree")
         yield Static(id="detail_panel")
         yield Footer()
 
     async def on_mount(self) -> None:
         self.storage = get_storage()
-        table = self.query_one(DataTable)
-        table.add_columns("ID", "Title", "Pri.", "Tags")
         await self.refresh_goals()
         self.set_interval(1.0, self._tick)
-        table.focus()
+        tree = self.query_one(Tree)
+        tree.focus()
 
     async def refresh_goals(self) -> None:
-        table = self.query_one(DataTable)
-        table.clear()
+        tree = self.query_one(Tree)
+        tree.root.remove_children()
         goals = list(self.storage.list_goals())
+        children: dict[str, list[Goal]] = {}
+        roots: list[Goal] = []
         for g in goals:
-            table.add_row(g.id, g.title, g.priority.value, ", ".join(g.tags), key=g.id)
-        if goals:
-            table.cursor_type = "row"
-            table.cursor_coordinate = Coordinate(0, 0)
+            if g.parent_id:
+                children.setdefault(g.parent_id, []).append(g)
+            else:
+                roots.append(g)
+        for lst in children.values():
+            lst.sort(key=lambda g: g.created)
+        roots.sort(key=lambda g: g.created)
 
-    async def on_data_table_row_highlighted(
-        self, event: DataTable.RowHighlighted
+        def add_nodes(node: TreeNode, goal: Goal) -> None:
+            branch = node.add(f"{goal.title}", goal.id)
+            for child in children.get(goal.id, []):
+                add_nodes(branch, child)
+
+        for g in roots:
+            add_nodes(tree.root, g)
+        tree.root.expand()
+
+    async def on_tree_node_highlighted(
+        self, event: Tree.NodeHighlighted[str]
     ) -> None:
-        self.selected_goal = str(event.row_key)
+        self.selected_goal = event.node.data
         self.update_detail()
 
     def update_detail(self) -> None:

--- a/rich/__init__.py
+++ b/rich/__init__.py
@@ -2,5 +2,14 @@ from .bar import Bar
 from .console import Console
 from .progress import Progress, SpinnerColumn, TextColumn
 from .table import Table
+from .tree import Tree
 
-__all__ = ["Console", "Table", "Bar", "Progress", "SpinnerColumn", "TextColumn"]
+__all__ = [
+    "Console",
+    "Table",
+    "Bar",
+    "Progress",
+    "SpinnerColumn",
+    "TextColumn",
+    "Tree",
+]

--- a/rich/tree.py
+++ b/rich/tree.py
@@ -1,0 +1,25 @@
+class Tree:
+    def __init__(self, label: str) -> None:
+        self.label = label
+        self.children: list[tuple[str, 'Tree']] = []
+
+    def add(self, label: str) -> 'Tree':
+        child = Tree(label)
+        self.children.append((label, child))
+        return child
+
+    def __str__(self) -> str:  # pragma: no cover - visual only
+        lines = [self.label]
+        for i, (label, child) in enumerate(self.children):
+            self._render_child(lines, label, child, "", i == len(self.children) - 1)
+        return "\n".join(lines)
+
+    def _render_child(
+        self, out: list[str], label: str, node: "Tree", prefix: str, last: bool
+    ) -> None:
+        connector = "└─ " if last else "├─ "
+        out.append(prefix + connector + label)
+        child_prefix = prefix + ("   " if last else "│  ")
+        for i, (lbl, child) in enumerate(node.children):
+            self._render_child(out, lbl, child, child_prefix, i == len(node.children) - 1)
+

--- a/rich/tree.py
+++ b/rich/tree.py
@@ -1,9 +1,9 @@
 class Tree:
     def __init__(self, label: str) -> None:
         self.label = label
-        self.children: list[tuple[str, 'Tree']] = []
+        self.children: list[tuple[str, "Tree"]] = []
 
-    def add(self, label: str) -> 'Tree':
+    def add(self, label: str) -> "Tree":
         child = Tree(label)
         self.children.append((label, child))
         return child
@@ -21,5 +21,6 @@ class Tree:
         out.append(prefix + connector + label)
         child_prefix = prefix + ("   " if last else "│  ")
         for i, (lbl, child) in enumerate(node.children):
-            self._render_child(out, lbl, child, child_prefix, i == len(node.children) - 1)
-
+            self._render_child(
+                out, lbl, child, child_prefix, i == len(node.children) - 1
+            )

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -8,6 +8,7 @@ from hypothesis import given, settings, strategies as st
 import pytest
 
 from goal_glide.models.session import PomodoroSession
+from goal_glide.models.goal import Goal
 from goal_glide.models.storage import Storage
 from goal_glide.services import analytics
 
@@ -36,6 +37,18 @@ def test_total_time_by_goal_simple(tmp_path: Path) -> None:
     totals = analytics.total_time_by_goal(storage)
     assert totals["g1"] == 90
     assert totals["g2"] == 20
+
+
+def test_total_time_by_goal_parent_accum(tmp_path: Path) -> None:
+    storage = Storage(tmp_path)
+    parent = Goal(id="p", title="p", created=datetime.now())
+    child = Goal(id="c", title="c", created=datetime.now(), parent_id="p")
+    storage.add_goal(parent)
+    storage.add_goal(child)
+    storage.add_session(make_session("c", datetime.now(), 30))
+    totals = analytics.total_time_by_goal(storage)
+    assert totals["c"] == 30
+    assert totals["p"] == 30
 
 
 def test_weekly_histogram_exact_bounds(tmp_path: Path) -> None:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -70,7 +70,7 @@ def test_add_and_archive_goal(app_env, tmp_path, monkeypatch):
     Pilot = _setup_textual()
     if Pilot is None:
         pytest.skip("textual not available")
-    from textual.widgets import DataTable
+    from textual.widgets import Tree
     from goal_glide.tui import GoalGlideApp
 
     monkeypatch.setattr("builtins.input", lambda *args: "new goal")
@@ -79,12 +79,12 @@ def test_add_and_archive_goal(app_env, tmp_path, monkeypatch):
         async with Pilot(GoalGlideApp) as pilot:
             await pilot.pause()
             await pilot.press("a")
-            table = pilot.app.query_one(DataTable)
+            tree = pilot.app.query_one(Tree)
             goals = Storage(tmp_path).list_goals()
-            assert table.row_count == 1
+            assert len(tree.root.children) == 1
             gid = goals[0].id
             await pilot.press("delete")
-            assert table.row_count == 0
+            assert len(tree.root.children) == 0
             assert Storage(tmp_path).get_goal(gid).archived is True
 
     asyncio.run(run())


### PR DESCRIPTION
## Summary
- add `--parent` option and `goal tree` command
- aggregate analytics totals up goal hierarchy
- switch TUI goal list to `Tree`
- provide minimal `rich.tree` implementation
- expand tests for hierarchy features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845227dd1d883229905400c31e2e6ed