### PR TITLE
Add notifier failure warning test

### DIFF
--- a/tests/test_reminder.py
+++ b/tests/test_reminder.py
@@ -88,3 +88,16 @@ def test_unknown_os_logs_info(
     caplog.set_level(logging.INFO)
     notify.push("msg")
     assert any("No notifier for OS" in rec.message for rec in caplog.records)
+
+
+def test_notifier_failure_logs_warning(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    def fail(_: str) -> None:
+        raise RuntimeError("nope")
+
+    monkeypatch.setitem(notify._OS_NOTIFIERS, "Darwin", fail)
+    monkeypatch.setattr(notify.platform, "system", lambda: "Darwin")
+    caplog.set_level(logging.WARNING)
+    notify.push("boom")
+    assert any("Notification failed" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- validate a warning is logged when notify push fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452649f84c832299ca09b374c2f0b6