### PR TITLE
Add reminder status default test

### DIFF
--- a/tests/test_reminder.py
+++ b/tests/test_reminder.py
@@ -74,6 +74,10 @@ def test_schedule_after_stop_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_reminder_status_output(runner: CliRunner) -> None:
+    result = runner.invoke(cli.goal, ["reminder", "status"])
+    assert result.exit_code == 0
+    assert "Enabled: False | Break: 5m | Interval: 30m" in result.output
+
     runner.invoke(cli.goal, ["reminder", "enable"])
     runner.invoke(
         cli.goal,


### PR DESCRIPTION
## Summary
- check reminder `status` command before enabling/configuring reminders

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452a668a308322b2fa34c7fa644236