### PR TITLE
Add streak and productivity insights

### DIFF
--- a/goal_glide/cli.py
+++ b/goal_glide/cli.py
@@ -31,6 +31,8 @@ from .services.analytics import (
     current_streak,
     total_time_by_goal,
     date_histogram,
+    most_productive_day,
+    longest_streak,
 )
 from .services.pomodoro import (
     load_active_session,
@@ -42,7 +44,7 @@ from .services.pomodoro import (
 from .models.session import PomodoroSession
 from .services.quotes import get_random_quote
 from .services.render import render_goals
-from .utils.format import format_duration
+from .utils.format import format_duration, format_duration_long
 from .utils.tag import validate_tag
 from .utils.timefmt import natural_delta
 
@@ -131,9 +133,7 @@ def add_goal(
     obj = cast(dict, ctx.obj)
     storage: Storage = obj["storage"]
     if storage.find_by_title(title):
-        console.print(
-            "[yellow]Warning: goal with this title already exists.[/yellow]"
-        )
+        console.print("[yellow]Warning: goal with this title already exists.[/yellow]")
 
     if parent_id is not None:
         storage.get_goal(parent_id)  # validate exists
@@ -681,6 +681,23 @@ def stats_cmd(
 
     streak = current_streak(storage, end)
     console.print(f"\N{FIRE}  Current streak: {streak} days")
+
+    longest = longest_streak(storage)
+    console.print(f"\N{HIGH VOLTAGE SIGN}  Longest streak: {longest} days")
+
+    full_hist = date_histogram(storage, start, end)
+    mpd = most_productive_day(storage, start, end)
+    if mpd:
+        totals: dict[str, int] = {}
+        counts: dict[str, int] = {}
+        for d, sec in full_hist.items():
+            name = d.strftime("%A")
+            totals[name] = totals.get(name, 0) + sec
+            counts[name] = counts.get(name, 0) + 1
+        avg = totals[mpd] // counts[mpd] if counts[mpd] else 0
+        console.print(
+            f"\N{CALENDAR}  Most productive day: {mpd} (avg. {format_duration_long(avg)})"
+        )
 
     if show_goals:
         totals = total_time_by_goal(storage, start, end)

--- a/goal_glide/templates/report_template.j2
+++ b/goal_glide/templates/report_template.j2
@@ -31,7 +31,12 @@ th { background: #f0f0f0; }
 {% endfor %}
 </table>
 <h2>Streak</h2>
-<p>{{ streak }}</p>
+<p>Current: {{ streak }} days<br>
+Longest: {{ longest }} days</p>
+{% if most_productive %}
+<h2>Most Productive Day</h2>
+<p>{{ most_productive }} (avg. {{ format_duration_long(avg_mpd) }})</p>
+{% endif %}
 <h2>Histogram</h2>
 <table>
 <tr><th>Date</th><th>Seconds</th></tr>

--- a/goal_glide/utils/format.py
+++ b/goal_glide/utils/format.py
@@ -7,4 +7,16 @@ def format_duration(sec: int) -> str:
     return f"{h:d}:{m:02d}"
 
 
-__all__ = ["format_duration"]
+def format_duration_long(sec: int) -> str:
+    """Format seconds as e.g. '2h 15m'."""
+    h = sec // 3600
+    m = (sec % 3600) // 60
+    parts = []
+    if h:
+        parts.append(f"{h}h")
+    if m or not parts:
+        parts.append(f"{m}m")
+    return " ".join(parts)
+
+
+__all__ = ["format_duration", "format_duration_long"]

--- a/tests/test_report_service.py
+++ b/tests/test_report_service.py
@@ -84,6 +84,7 @@ def test_html_contains_sections(
     assert "Total Focus Time" in text
     assert "Top Goals" in text
     assert "Histogram" in text
+    assert "Most Productive Day" in text
 
 
 def test_markdown_formatting(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_stats_cmd.py
+++ b/tests/test_stats_cmd.py
@@ -45,6 +45,8 @@ def test_stats_week_output_has_7_bars(
     )
     lines = [line for line in result.output.splitlines() if "[" in line]
     assert len(lines) == 7
+    assert "Longest streak" in result.output
+    assert "Most productive day" in result.output
 
 
 def test_stats_month_output_has_4_bars(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,6 +13,12 @@ def test_format_duration_basic() -> None:
     assert fmt.format_duration(3661) == "1:01"
 
 
+def test_format_duration_long() -> None:
+    assert fmt.format_duration_long(0) == "0m"
+    assert fmt.format_duration_long(3600) == "1h"
+    assert fmt.format_duration_long(3661) == "1h 1m"
+
+
 def test_natural_delta_formats(monkeypatch: pytest.MonkeyPatch) -> None:
     fixed_now = datetime(2023, 1, 2, 12, 0, 0)
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- show longest streak and most productive day in `stats`
- include new metrics in reports
- support human readable durations
- update HTML template with longest/most productive info
- test coverage for new helpers and outputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684529520488832292d606e088d98390