### PR TITLE
Parametrize invalid reminder config tests

### DIFF
--- a/tests/test_reminder.py
+++ b/tests/test_reminder.py
@@ -35,15 +35,18 @@ def test_config_command_updates_values(runner: CliRunner) -> None:
     assert cfg.reminder_interval() == 15
 
 
-def test_invalid_break_value_errors(runner: CliRunner) -> None:
-    result = runner.invoke(cli.goal, ["reminder", "config", "--break", "200"])
+@pytest.mark.parametrize("val", [0, -5, 200])
+def test_invalid_break_value_errors(val: int, runner: CliRunner) -> None:
+    result = runner.invoke(cli.goal, ["reminder", "config", "--break", str(val)])
     assert result.exit_code != 0
+    assert "break must be between 1 and 120" in result.output
 
 
-def test_invalid_interval_value_errors(runner: CliRunner) -> None:
-    result = CliRunner().invoke(cli.goal, ["reminder", "config", "--interval", "200"])
+@pytest.mark.parametrize("val", [0, -5, 200])
+def test_invalid_interval_value_errors(val: int, runner: CliRunner) -> None:
+    result = runner.invoke(cli.goal, ["reminder", "config", "--interval", str(val)])
     assert result.exit_code != 0
-    assert "interval must be" in result.output
+    assert "interval must be between 1 and 120" in result.output
 
 
 def test_notification_backend_selection(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- expand reminder config invalid value tests
- use `pytest.mark.parametrize` for multiple bad values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452d42dd548322ba143b528bf27fa5