### PR TITLE
Implement goal deadlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Features include:
 - Capture quick thoughts and attach them to goals
 - Display focus statistics and streaks
 - Optional Textual based TUI for an interactive view
+- Set deadlines on goals with visual warnings when approaching
 
 ## Installation
 
@@ -147,15 +148,15 @@ Quick examples of common commands:
 
 - **add** – create a goal.
   ```bash
-  python -m goal_glide add "Read more books"
+  python -m goal_glide add "Read more books" --deadline 2030-01-01
   ```
 - **remove** – delete a goal permanently.
   ```bash
   python -m goal_glide remove <goal-id>
   ```
-- **update** – change a goal's title or priority.
+- **update** – change a goal's title, priority or deadline.
   ```bash
-  python -m goal_glide update <goal-id> --title "New title" --priority high
+  python -m goal_glide update <goal-id> --title "New title" --priority high --deadline 2030-01-01
   ```
 - **archive** / **restore** – hide or unhide a goal.
   ```bash

--- a/goal_glide/cli.py
+++ b/goal_glide/cli.py
@@ -119,10 +119,19 @@ def goal(ctx: click.Context) -> None:
     show_default=True,
     help="Goal priority (low, medium, high)",
 )
+@click.option(
+    "--deadline",
+    type=click.DateTime(formats=["%Y-%m-%d"]),
+    help="Deadline YYYY-MM-DD",
+)
 @click.option("--parent", "parent_id", help="Parent goal ID")
 @click.pass_context
 def add_goal(
-    ctx: click.Context, title: str, priority: str, parent_id: str | None
+    ctx: click.Context,
+    title: str,
+    priority: str,
+    deadline: datetime | None,
+    parent_id: str | None,
 ) -> None:
     """Add a new goal."""
     title = title.strip()
@@ -144,6 +153,7 @@ def add_goal(
         title=title,
         created=datetime.utcnow(),
         priority=prio,
+        deadline=deadline,
         parent_id=parent_id,
     )
     storage.add_goal(g)
@@ -195,10 +205,19 @@ def restore_goal_cmd(ctx: click.Context, goal_id: str) -> None:
     type=click.Choice([e.value for e in Priority]),
     help="Goal priority (low, medium, high)",
 )
+@click.option(
+    "--deadline",
+    type=click.DateTime(formats=["%Y-%m-%d"]),
+    help="Deadline YYYY-MM-DD",
+)
 @handle_exceptions
 @click.pass_context
 def update_goal_cmd(
-    ctx: click.Context, goal_id: str, title: str | None, priority: str | None
+    ctx: click.Context,
+    goal_id: str,
+    title: str | None,
+    priority: str | None,
+    deadline: datetime | None,
 ) -> None:
     """Modify goal attributes."""
     obj = cast(dict, ctx.obj)
@@ -214,6 +233,7 @@ def update_goal_cmd(
         new_title = title
 
     new_priority = goal.priority if priority is None else Priority(priority)
+    new_deadline = goal.deadline if deadline is None else deadline
 
     updated = Goal(
         id=goal.id,
@@ -223,6 +243,7 @@ def update_goal_cmd(
         archived=goal.archived,
         tags=goal.tags,
         parent_id=goal.parent_id,
+        deadline=new_deadline,
     )
     storage.update_goal(updated)
     console.print(f":pencil: Updated goal {updated.id}")

--- a/goal_glide/models/goal.py
+++ b/goal_glide/models/goal.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import Optional
 from enum import Enum
 
 
@@ -20,3 +21,4 @@ class Goal:
     archived: bool = False
     tags: list[str] = field(default_factory=list)
     parent_id: str | None = None
+    deadline: Optional[datetime] = None

--- a/goal_glide/models/storage.py
+++ b/goal_glide/models/storage.py
@@ -50,10 +50,13 @@ class Storage:
         else:
             created_dt = created
         dl = row.get("deadline")
+        dl_dt: datetime | None
         if isinstance(dl, str):
             dl_dt = datetime.fromisoformat(dl)
-        else:
+        elif isinstance(dl, datetime):
             dl_dt = dl
+        else:
+            dl_dt = None
         return Goal(
             id=row["id"],
             title=row["title"],

--- a/goal_glide/models/storage.py
+++ b/goal_glide/models/storage.py
@@ -37,6 +37,9 @@ class Storage:
             if "parent_id" not in row:
                 new_row["parent_id"] = None
                 updated = True
+            if "deadline" not in row:
+                new_row["deadline"] = None
+                updated = True
             if updated:
                 self.table.update(new_row, Query().id == row["id"])
 
@@ -46,6 +49,11 @@ class Storage:
             created_dt = datetime.fromisoformat(created)
         else:
             created_dt = created
+        dl = row.get("deadline")
+        if isinstance(dl, str):
+            dl_dt = datetime.fromisoformat(dl)
+        else:
+            dl_dt = dl
         return Goal(
             id=row["id"],
             title=row["title"],
@@ -54,6 +62,7 @@ class Storage:
             archived=row.get("archived", False),
             tags=row.get("tags", []),
             parent_id=row.get("parent_id"),
+            deadline=dl_dt,
         )
 
     def _row_to_thought(self, row: dict[str, Any]) -> Thought:
@@ -104,6 +113,7 @@ class Storage:
             archived=goal.archived,
             tags=sorted(updated_tags),
             parent_id=goal.parent_id,
+            deadline=goal.deadline,
         )
         self.update_goal(updated)
         return updated
@@ -121,6 +131,7 @@ class Storage:
             archived=goal.archived,
             tags=new_tags,
             parent_id=goal.parent_id,
+            deadline=goal.deadline,
         )
         self.update_goal(updated)
         return updated
@@ -144,6 +155,7 @@ class Storage:
             archived=True,
             tags=goal.tags,
             parent_id=goal.parent_id,
+            deadline=goal.deadline,
         )
         self.update_goal(updated)
         return updated
@@ -160,6 +172,7 @@ class Storage:
             archived=False,
             tags=goal.tags,
             parent_id=goal.parent_id,
+            deadline=goal.deadline,
         )
         self.update_goal(updated)
         return updated

--- a/goal_glide/services/render.py
+++ b/goal_glide/services/render.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta
 from rich.table import Table
 
 from ..models.goal import Goal
@@ -11,14 +12,26 @@ def render_goals(goals: list[Goal]) -> Table:
     table.add_column("Title")
     table.add_column("Priority")
     table.add_column("Created")
+    table.add_column("Deadline")
     table.add_column("Archived")
     table.add_column("Tags")
     for g in goals:
+        deadline_text = ""
+        if g.deadline:
+            date_str = g.deadline.date().isoformat()
+            now = datetime.utcnow()
+            if g.deadline < now:
+                deadline_text = f"[red]{date_str}[/]"
+            elif g.deadline - now <= timedelta(days=3):
+                deadline_text = f"[yellow]{date_str}[/]"
+            else:
+                deadline_text = date_str
         table.add_row(
             g.id,
             g.title,
             g.priority.value,
             g.created.isoformat(timespec="seconds"),
+            deadline_text,
             "yes" if g.archived else "",
             ", ".join(g.tags),
         )

--- a/tests/test_goal_archive.py
+++ b/tests/test_goal_archive.py
@@ -29,6 +29,13 @@ def test_add_with_priority(tmp_path: Path, runner: CliRunner) -> None:
     assert goals[0].priority == Priority.high
 
 
+def test_add_with_deadline(tmp_path: Path, runner: CliRunner) -> None:
+    runner.invoke(goal, ["add", "Test goal", "--deadline", "2030-01-01"])
+    storage = Storage(tmp_path)
+    goals = storage.list_goals()
+    assert goals[0].deadline.strftime("%Y-%m-%d") == "2030-01-01"
+
+
 def test_archive_sets_flag(tmp_path: Path, runner: CliRunner) -> None:
     result = runner.invoke(goal, ["add", "Test goal"])
     assert result.exit_code == 0

--- a/tests/test_goal_update.py
+++ b/tests/test_goal_update.py
@@ -28,3 +28,17 @@ def test_update_priority(tmp_path: Path, runner: CliRunner) -> None:
     result = runner.invoke(goal, ["update", gid, "--priority", "high"])
     assert result.exit_code == 0
     assert Storage(tmp_path).get_goal(gid).priority == Priority.high
+
+
+def test_update_deadline(tmp_path: Path, runner: CliRunner) -> None:
+    runner.invoke(goal, ["add", "g"])
+    gid = Storage(tmp_path).list_goals()[0].id
+    result = runner.invoke(
+        goal,
+        ["update", gid, "--deadline", "2030-01-01"],
+    )
+    assert result.exit_code == 0
+    assert (
+        Storage(tmp_path).get_goal(gid).deadline.strftime("%Y-%m-%d")
+        == "2030-01-01"
+    )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -16,6 +16,7 @@ def test_goal_defaults() -> None:
     assert g.archived is False
     assert g.tags == []
     assert g.parent_id is None
+    assert g.deadline is None
 
 
 def test_goal_nondefaults() -> None:
@@ -27,11 +28,13 @@ def test_goal_nondefaults() -> None:
         archived=True,
         tags=["a"],
         parent_id="p",
+        deadline=datetime(2030, 1, 1),
     )
     assert g.priority == Priority.high
     assert g.archived is True
     assert "a" in g.tags
     assert g.parent_id == "p"
+    assert g.deadline == datetime(2030, 1, 1)
 
 
 def test_session_new_generates_id() -> None:

--- a/tests/test_render_service.py
+++ b/tests/test_render_service.py
@@ -6,8 +6,19 @@ from goal_glide.services.render import render_goals
 
 def test_render_goals_row_count() -> None:
     goals = [
-        Goal(id="1", title="A", created=datetime.utcnow(), priority=Priority.low),
-        Goal(id="2", title="B", created=datetime.utcnow(), archived=True, deadline=datetime.utcnow()),
+        Goal(
+            id="1",
+            title="A",
+            created=datetime.utcnow(),
+            priority=Priority.low,
+        ),
+        Goal(
+            id="2",
+            title="B",
+            created=datetime.utcnow(),
+            archived=True,
+            deadline=datetime.utcnow(),
+        ),
     ]
     table = render_goals(goals)
     assert len(table.rows) == len(goals)

--- a/tests/test_render_service.py
+++ b/tests/test_render_service.py
@@ -7,8 +7,9 @@ from goal_glide.services.render import render_goals
 def test_render_goals_row_count() -> None:
     goals = [
         Goal(id="1", title="A", created=datetime.utcnow(), priority=Priority.low),
-        Goal(id="2", title="B", created=datetime.utcnow(), archived=True),
+        Goal(id="2", title="B", created=datetime.utcnow(), archived=True, deadline=datetime.utcnow()),
     ]
     table = render_goals(goals)
     assert len(table.rows) == len(goals)
     assert table.columns[0] == "ID"
+    assert "Deadline" in table.columns


### PR DESCRIPTION
## Summary
- allow setting deadlines on goals
- expose `--deadline` option for add and update commands
- highlight approaching/overdue deadlines when rendering goals and in the TUI
- document deadlines in README
- test deadline behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452d57a8fc8322933ddc51c3e79f03