### PR TITLE
Add scheduler None cancel test

### DIFF
--- a/tests/test_reminder.py
+++ b/tests/test_reminder.py
@@ -229,3 +229,11 @@ def test_cancel_all_calls_remove_all_jobs(monkeypatch: pytest.MonkeyPatch) -> No
     reminder.cancel_all()
 
     assert calls == ["removed"]
+
+
+def test_cancel_all_no_scheduler(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(reminder, "_sched", None)
+
+    reminder.cancel_all()
+
+    assert reminder._sched is None


### PR DESCRIPTION
## Summary
- test that `cancel_all` behaves when `_sched` is `None`

## Testing
- `pytest tests/test_reminder.py::test_cancel_all_no_scheduler -q`

------
https://chatgpt.com/codex/tasks/task_e_68452ec527bc83229d6e8c75d8e7b48c