### PR TITLE
Improve type hints with TypedDict

### DIFF
--- a/goal_glide/cli.py
+++ b/goal_glide/cli.py
@@ -95,7 +95,7 @@ def _fmt(seconds: int) -> str:
     return f"{mins}m"
 
 
-def _print_completion(session: PomodoroSession, config: dict) -> None:
+def _print_completion(session: PomodoroSession, config: ConfigDict) -> None:
     console.print(f"Pomodoro complete ✅ ({_fmt(session.duration_sec)})")
     if config.get("quotes_enabled", True):
         quote, author = get_random_quote()

--- a/goal_glide/cli.py
+++ b/goal_glide/cli.py
@@ -5,7 +5,7 @@ import os
 import uuid
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Callable, ParamSpec, TypeVar, cast
+from typing import Callable, ParamSpec, TypeVar, cast, TypedDict
 
 import click
 
@@ -16,7 +16,7 @@ from rich.table import Table
 from rich.tree import Tree
 from tinydb import Query
 
-from .config import load_config, save_config
+from .config import ConfigDict, load_config, save_config
 from .exceptions import (
     GoalAlreadyArchivedError,
     GoalNotArchivedError,
@@ -52,6 +52,11 @@ console = Console()
 
 P = ParamSpec("P")
 R = TypeVar("R")
+
+
+class AppContext(TypedDict):
+    storage: Storage
+    config: ConfigDict
 
 
 # ── Centralised exception handler ────────────────────────────────────────────
@@ -103,10 +108,9 @@ def _print_completion(session: PomodoroSession, config: dict) -> None:
 @click.pass_context
 def goal(ctx: click.Context) -> None:
     """Goal management CLI."""
-    ctx.obj = {
-        "storage": get_storage(),
-        "config": load_config(),
-    }
+    storage = get_storage()
+    config = load_config()
+    ctx.obj = cast(AppContext, {"storage": storage, "config": config})
 
 
 @goal.command("add")
@@ -147,7 +151,7 @@ def add_goal(
         console.print("[red]Title cannot be empty.[/red]")
         raise SystemExit(1)
 
-    obj = cast(dict, ctx.obj)
+    obj = cast(AppContext, ctx.obj)
     storage: Storage = obj["storage"]
     if storage.find_by_title(title):
         console.print("[yellow]Warning: goal with this title already exists.[/yellow]")
@@ -174,7 +178,7 @@ def add_goal(
 @click.pass_context
 def remove_goal_cmd(ctx: click.Context, goal_id: str) -> None:
     """Permanently remove a goal."""
-    obj = cast(dict, ctx.obj)
+    obj = cast(AppContext, ctx.obj)
     storage: Storage = obj["storage"]
     if click.confirm(f"Remove goal {goal_id}?"):
         storage.remove_goal(goal_id)
@@ -187,7 +191,7 @@ def remove_goal_cmd(ctx: click.Context, goal_id: str) -> None:
 @click.pass_context
 def archive_goal_cmd(ctx: click.Context, goal_id: str) -> None:
     """Hide a goal from normal listings."""
-    obj = cast(dict, ctx.obj)
+    obj = cast(AppContext, ctx.obj)
     storage: Storage = obj["storage"]
     storage.archive_goal(goal_id)
     console.print(f":package: Goal {goal_id} archived")
@@ -199,7 +203,7 @@ def archive_goal_cmd(ctx: click.Context, goal_id: str) -> None:
 @click.pass_context
 def restore_goal_cmd(ctx: click.Context, goal_id: str) -> None:
     """Bring a goal back into the active list."""
-    obj = cast(dict, ctx.obj)
+    obj = cast(AppContext, ctx.obj)
     storage: Storage = obj["storage"]
     storage.restore_goal(goal_id)
     console.print(f":package: Goal {goal_id} restored")
@@ -239,7 +243,7 @@ def update_goal_cmd(
         priority: The new priority for the goal.
         deadline: The new deadline for the goal.
     """
-    obj = cast(dict, ctx.obj)
+    obj = cast(AppContext, ctx.obj)
     storage: Storage = obj["storage"]
     goal = storage.get_goal(goal_id)
 
@@ -281,7 +285,7 @@ def tag() -> None:
 @click.pass_context
 def tag_add(ctx: click.Context, goal_id: str, tags: tuple[str, ...]) -> None:
     """Add one or more tags to a goal."""
-    obj = cast(dict, ctx.obj)
+    obj = cast(AppContext, ctx.obj)
     storage: Storage = obj["storage"]
     validated = [validate_tag(t) for t in tags]
     goal = storage.add_tags(goal_id, validated)
@@ -295,7 +299,7 @@ def tag_add(ctx: click.Context, goal_id: str, tags: tuple[str, ...]) -> None:
 @click.pass_context
 def tag_rm(ctx: click.Context, goal_id: str, tag: str) -> None:
     """Remove a tag from a goal."""
-    obj = cast(dict, ctx.obj)
+    obj = cast(AppContext, ctx.obj)
     storage: Storage = obj["storage"]
     validated = validate_tag(tag)
     before = storage.get_goal(goal_id)
@@ -309,7 +313,7 @@ def tag_rm(ctx: click.Context, goal_id: str, tag: str) -> None:
 @click.pass_context
 def tag_list(ctx: click.Context) -> None:
     """List all tags with goal counts."""
-    obj = cast(dict, ctx.obj)
+    obj = cast(AppContext, ctx.obj)
     storage: Storage = obj["storage"]
     tags = storage.list_all_tags()
     if not tags:
@@ -354,7 +358,7 @@ def list_goals(
         priority: Filters the list to goals of a specific priority.
         tags: Filters the list to goals that have all the specified tags.
     """
-    obj = cast(dict, ctx.obj)
+    obj = cast(AppContext, ctx.obj)
     storage: Storage = obj["storage"]
     goals = storage.list_goals(
         include_archived=show_all,
@@ -374,7 +378,7 @@ def list_goals(
 @click.pass_context
 def goal_tree(ctx: click.Context) -> None:
     """Display goals in a tree view."""
-    obj = cast(dict, ctx.obj)
+    obj = cast(AppContext, ctx.obj)
     storage: Storage = obj["storage"]
     goals = storage.list_goals()
 
@@ -424,7 +428,7 @@ def start_pomo(duration: int, goal_id: str | None) -> None:
 @click.pass_context
 def stop_pomo(ctx: click.Context) -> None:
     session = stop_session()
-    obj = cast(dict, ctx.obj)
+    obj = cast(AppContext, ctx.obj)
     storage: Storage = obj["storage"]
     storage.add_session(
         PomodoroSession.new(session.goal_id, session.start, session.duration_sec)
@@ -473,7 +477,7 @@ def reminder_cli() -> None:
 @handle_exceptions
 @click.pass_context
 def reminder_enable(ctx: click.Context) -> None:
-    obj = cast(dict, ctx.obj)
+    obj = cast(AppContext, ctx.obj)
     cfg = obj["config"]
     cfg["reminders_enabled"] = True
     save_config(cfg)
@@ -484,7 +488,7 @@ def reminder_enable(ctx: click.Context) -> None:
 @handle_exceptions
 @click.pass_context
 def reminder_disable(ctx: click.Context) -> None:
-    obj = cast(dict, ctx.obj)
+    obj = cast(AppContext, ctx.obj)
     cfg = obj["config"]
     cfg["reminders_enabled"] = False
     save_config(cfg)
@@ -499,7 +503,7 @@ def reminder_disable(ctx: click.Context) -> None:
 def reminder_config(
     ctx: click.Context, break_: int | None, interval: int | None
 ) -> None:
-    obj = cast(dict, ctx.obj)
+    obj = cast(AppContext, ctx.obj)
     cfg = obj["config"]
     if break_ is not None:
         if not 1 <= break_ <= 120:
@@ -518,7 +522,7 @@ def reminder_config(
 @reminder_cli.command("status")
 @click.pass_context
 def reminder_status(ctx: click.Context) -> None:
-    obj = cast(dict, ctx.obj)
+    obj = cast(AppContext, ctx.obj)
     cfg = obj["config"]
     enabled = cfg.get("reminders_enabled", False)
     break_min = cfg.get("reminder_break_min", 5)
@@ -544,7 +548,7 @@ def config() -> None:
 @click.option("--enable/--disable", default=None, help="Toggle motivational quotes")
 @click.pass_context
 def cfg_quotes(ctx: click.Context, enable: bool | None) -> None:
-    obj = cast(dict, ctx.obj)
+    obj = cast(AppContext, ctx.obj)
     cfg = obj["config"]
     if enable is not None:
         cfg["quotes_enabled"] = enable
@@ -556,7 +560,7 @@ def cfg_quotes(ctx: click.Context, enable: bool | None) -> None:
 @click.pass_context
 def cfg_show(ctx: click.Context) -> None:
     """Show current configuration."""
-    obj = cast(dict, ctx.obj)
+    obj = cast(AppContext, ctx.obj)
     cfg = obj["config"]
     table = Table(title="Config")
     table.add_column("Key")
@@ -573,10 +577,10 @@ goal.add_command(config)
 @click.pass_context
 def thought(ctx: click.Context) -> None:
     if ctx.obj is None:
-        ctx.obj = {
-            "storage": get_storage(),
-            "config": load_config(),
-        }
+        ctx.obj = cast(
+            AppContext,
+            {"storage": get_storage(), "config": load_config()},
+        )
 
 
 goal.add_command(thought)
@@ -589,7 +593,7 @@ goal.add_command(thought)
 @click.pass_context
 def jot_thought(ctx: click.Context, message: str | None, goal_id: str | None) -> None:
     """Record a short thought or reflection."""
-    obj = cast(dict, ctx.obj)
+    obj = cast(AppContext, ctx.obj)
     storage: Storage = obj["storage"]
 
     if message is None:
@@ -620,7 +624,7 @@ def jot_thought(ctx: click.Context, message: str | None, goal_id: str | None) ->
 @click.pass_context
 def list_thoughts_cmd(ctx: click.Context, goal_id: str | None, limit: int) -> None:
     """Display recent thoughts."""
-    obj = cast(dict, ctx.obj)
+    obj = cast(AppContext, ctx.obj)
     storage: Storage = obj["storage"]
     thoughts = storage.list_thoughts(goal_id=goal_id, limit=limit, newest_first=True)
 
@@ -649,7 +653,7 @@ def list_thoughts_cmd(ctx: click.Context, goal_id: str | None, limit: int) -> No
 @click.pass_context
 def remove_thought_cmd(ctx: click.Context, thought_id: str) -> None:
     """Delete a thought."""
-    obj = cast(dict, ctx.obj)
+    obj = cast(AppContext, ctx.obj)
     storage: Storage = obj["storage"]
     if storage.remove_thought(thought_id):
         console.print(f"[green]Removed[/green] {thought_id}")
@@ -681,7 +685,7 @@ def stats_cmd(
     end_date: datetime | None,
 ) -> None:
     """Visualise focus stats and streaks."""
-    obj = cast(dict, ctx.obj)
+    obj = cast(AppContext, ctx.obj)
     storage: Storage = obj["storage"]
     today = datetime.now().date()
 
@@ -825,7 +829,7 @@ def report_make(
         if range_all
         else "week"
     )
-    obj = cast(dict, ctx.obj)
+    obj = cast(AppContext, ctx.obj)
     storage: Storage = obj["storage"]
     start = start_date.date() if start_date else None
     end = end_date.date() if end_date else None

--- a/goal_glide/config.py
+++ b/goal_glide/config.py
@@ -2,9 +2,16 @@ from __future__ import annotations
 
 import tomllib
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, TypedDict
 
-DEFAULTS: Dict[str, Any] = {
+
+class ConfigDict(TypedDict):
+    quotes_enabled: bool
+    reminders_enabled: bool
+    reminder_break_min: int
+    reminder_interval_min: int
+
+DEFAULTS: ConfigDict = {
     "quotes_enabled": True,
     "reminders_enabled": False,
     "reminder_break_min": 5,
@@ -21,9 +28,10 @@ def _load_file() -> Dict[str, Any]:
     return {}
 
 
-def _config() -> Dict[str, Any]:
+def _config() -> ConfigDict:
     data = _load_file()
-    return DEFAULTS | data
+    full_cfg: ConfigDict = {**DEFAULTS, **data}
+    return full_cfg
 
 
 def quotes_enabled() -> bool:
@@ -42,11 +50,13 @@ def reminder_interval() -> int:
     return int(_config().get("reminder_interval_min", 30))
 
 
-def load_config() -> Dict[str, Any]:
-    return dict(_config())
+def load_config() -> ConfigDict:
+    file_cfg = _load_file()
+    full_cfg: ConfigDict = {**DEFAULTS, **file_cfg}
+    return full_cfg
 
 
-def save_config(cfg: Dict[str, Any]) -> None:
+def save_config(cfg: ConfigDict) -> None:
     _CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
     items = []
     for k, v in cfg.items():

--- a/goal_glide/config.py
+++ b/goal_glide/config.py
@@ -11,6 +11,7 @@ class ConfigDict(TypedDict):
     reminder_break_min: int
     reminder_interval_min: int
 
+
 DEFAULTS: ConfigDict = {
     "quotes_enabled": True,
     "reminders_enabled": False,

--- a/goal_glide/config.py
+++ b/goal_glide/config.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import tomllib
 from pathlib import Path
-from typing import Any, Dict, TypedDict
+from typing import Any, Dict, TypedDict, cast
 
 
-class ConfigDict(TypedDict):
+class ConfigDict(TypedDict, total=False):
     quotes_enabled: bool
     reminders_enabled: bool
     reminder_break_min: int
@@ -30,7 +30,7 @@ def _load_file() -> Dict[str, Any]:
 
 
 def _config() -> ConfigDict:
-    data = _load_file()
+    data = cast(ConfigDict, _load_file())
     full_cfg: ConfigDict = {**DEFAULTS, **data}
     return full_cfg
 
@@ -52,7 +52,7 @@ def reminder_interval() -> int:
 
 
 def load_config() -> ConfigDict:
-    file_cfg = _load_file()
+    file_cfg = cast(ConfigDict, _load_file())
     full_cfg: ConfigDict = {**DEFAULTS, **file_cfg}
     return full_cfg
 

--- a/goal_glide/models/storage.py
+++ b/goal_glide/models/storage.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from pathlib import Path
-from typing import Any, TypedDict, cast
+from typing import TypedDict, cast
 
 from tinydb import Query, TinyDB
 
@@ -292,7 +292,8 @@ class Storage:
         self.session_table.insert(cast(SessionRow, asdict(session)))
 
     def list_sessions(self) -> list[PomodoroSession]:
-        return [self._row_to_session(cast(SessionRow, r)) for r in self.session_table.all()]
+        rows = self.session_table.all()
+        return [self._row_to_session(cast(SessionRow, r)) for r in rows]
 
     def add_thought(self, thought: Thought) -> None:
         from dataclasses import asdict

--- a/goal_glide/models/storage.py
+++ b/goal_glide/models/storage.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from pathlib import Path
-from typing import TypedDict, cast
+from typing import Any, TypedDict, cast
 
 from tinydb import Query, TinyDB
 
@@ -141,7 +141,7 @@ class Storage:
 
         from dataclasses import asdict
 
-        self.table.insert(cast(GoalRow, asdict(goal)))
+        self.table.insert(cast(dict[str, Any], asdict(goal)))
 
     def get_goal(self, goal_id: str) -> Goal:
         row = self.table.get(Query().id == goal_id)
@@ -188,7 +188,7 @@ class Storage:
 
         if not self.table.contains(Query().id == goal.id):
             raise GoalNotFoundError(f"Goal {goal.id} not found")
-        self.table.update(cast(GoalRow, asdict(goal)), Query().id == goal.id)
+        self.table.update(cast(dict[str, Any], asdict(goal)), Query().id == goal.id)
 
     def archive_goal(self, goal_id: str) -> Goal:
         goal = self.get_goal(goal_id)
@@ -262,8 +262,9 @@ class Storage:
         if parent_id is not None:
             predicates.append(GoalQuery.parent_id == parent_id)
 
-        def predicate(row: GoalRow) -> bool:
-            return all(p(row) for p in predicates)
+        def predicate(row: dict[str, Any]) -> bool:
+            row_t = cast(GoalRow, row)
+            return all(p(row_t) for p in predicates)
 
         rows = self.table.search(predicate) if predicates else self.table.all()
         return [self._row_to_goal(cast(GoalRow, r)) for r in rows]
@@ -289,7 +290,7 @@ class Storage:
     def add_session(self, session: PomodoroSession) -> None:
         from dataclasses import asdict
 
-        self.session_table.insert(cast(SessionRow, asdict(session)))
+        self.session_table.insert(cast(dict[str, Any], asdict(session)))
 
     def list_sessions(self) -> list[PomodoroSession]:
         rows = self.session_table.all()
@@ -298,7 +299,7 @@ class Storage:
     def add_thought(self, thought: Thought) -> None:
         from dataclasses import asdict
 
-        self.thought_table.insert(cast(ThoughtRow, asdict(thought)))
+        self.thought_table.insert(cast(dict[str, Any], asdict(thought)))
 
     def list_thoughts(
         self,

--- a/goal_glide/models/storage.py
+++ b/goal_glide/models/storage.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict, cast
 
 from tinydb import Query, TinyDB
 
@@ -15,6 +15,31 @@ from .goal import Goal, Priority
 from .session import PomodoroSession
 from .thought import TABLE_NAME as THOUGHTS_TABLE
 from .thought import Thought
+
+
+class GoalRow(TypedDict):
+    id: str
+    title: str
+    created: datetime | str
+    priority: str
+    archived: bool
+    tags: list[str]
+    parent_id: str | None
+    deadline: datetime | str | None
+
+
+class ThoughtRow(TypedDict):
+    id: str
+    text: str
+    timestamp: datetime | str
+    goal_id: str | None
+
+
+class SessionRow(TypedDict):
+    id: str
+    goal_id: str | None
+    start: datetime | str
+    duration_sec: int
 
 
 class Storage:
@@ -56,7 +81,7 @@ class Storage:
             if updated:
                 self.table.update(new_row, Query().id == row["id"])
 
-    def _row_to_goal(self, row: dict[str, Any]) -> Goal:
+    def _row_to_goal(self, row: GoalRow) -> Goal:
         created = row["created"]
         if isinstance(created, str):
             created_dt = datetime.fromisoformat(created)
@@ -81,7 +106,7 @@ class Storage:
             deadline=dl_dt,
         )
 
-    def _row_to_thought(self, row: dict[str, Any]) -> Thought:
+    def _row_to_thought(self, row: ThoughtRow) -> Thought:
         ts = row["timestamp"]
         if isinstance(ts, str):
             ts_dt = datetime.fromisoformat(ts)
@@ -94,7 +119,7 @@ class Storage:
             goal_id=row.get("goal_id"),
         )
 
-    def _row_to_session(self, row: dict[str, Any]) -> PomodoroSession:
+    def _row_to_session(self, row: SessionRow) -> PomodoroSession:
         st = row["start"]
         if isinstance(st, str):
             st_dt = datetime.fromisoformat(st)
@@ -116,13 +141,13 @@ class Storage:
 
         from dataclasses import asdict
 
-        self.table.insert(asdict(goal))
+        self.table.insert(cast(GoalRow, asdict(goal)))
 
     def get_goal(self, goal_id: str) -> Goal:
         row = self.table.get(Query().id == goal_id)
         if not row:
             raise GoalNotFoundError(f"Goal {goal_id} not found")
-        return self._row_to_goal(row)
+        return self._row_to_goal(cast(GoalRow, row))
 
     def add_tags(self, goal_id: str, tags: list[str]) -> Goal:
         goal = self.get_goal(goal_id)
@@ -163,7 +188,7 @@ class Storage:
 
         if not self.table.contains(Query().id == goal.id):
             raise GoalNotFoundError(f"Goal {goal.id} not found")
-        self.table.update(asdict(goal), Query().id == goal.id)
+        self.table.update(cast(GoalRow, asdict(goal)), Query().id == goal.id)
 
     def archive_goal(self, goal_id: str) -> Goal:
         goal = self.get_goal(goal_id)
@@ -237,17 +262,18 @@ class Storage:
         if parent_id is not None:
             predicates.append(GoalQuery.parent_id == parent_id)
 
-        def predicate(row: dict[str, Any]) -> bool:
+        def predicate(row: GoalRow) -> bool:
             return all(p(row) for p in predicates)
 
         rows = self.table.search(predicate) if predicates else self.table.all()
-        return [self._row_to_goal(r) for r in rows]
+        return [self._row_to_goal(cast(GoalRow, r)) for r in rows]
 
     def list_all_tags(self) -> dict[str, int]:
         """Return mapping of tag name to count of goals containing it."""
         counts: dict[str, int] = {}
         for row in self.table.all():
-            for tag in row.get("tags", []):
+            goal_row = cast(GoalRow, row)
+            for tag in goal_row.get("tags", []):
                 counts[tag] = counts.get(tag, 0) + 1
         return counts
 
@@ -258,20 +284,20 @@ class Storage:
 
     def find_by_title(self, title: str) -> Goal | None:
         row = self.table.get(Query().title == title)
-        return self._row_to_goal(row) if row else None
+        return self._row_to_goal(cast(GoalRow, row)) if row else None
 
     def add_session(self, session: PomodoroSession) -> None:
         from dataclasses import asdict
 
-        self.session_table.insert(asdict(session))
+        self.session_table.insert(cast(SessionRow, asdict(session)))
 
     def list_sessions(self) -> list[PomodoroSession]:
-        return [self._row_to_session(r) for r in self.session_table.all()]
+        return [self._row_to_session(cast(SessionRow, r)) for r in self.session_table.all()]
 
     def add_thought(self, thought: Thought) -> None:
         from dataclasses import asdict
 
-        self.thought_table.insert(asdict(thought))
+        self.thought_table.insert(cast(ThoughtRow, asdict(thought)))
 
     def list_thoughts(
         self,
@@ -286,7 +312,7 @@ class Storage:
         else:
             db_rows = self.thought_table.all()
 
-        rows = [self._row_to_thought(r) for r in db_rows]
+        rows = [self._row_to_thought(cast(ThoughtRow, r)) for r in db_rows]
         rows.sort(key=lambda t: t.timestamp, reverse=newest_first)
         if limit is not None:
             rows = rows[:limit]

--- a/goal_glide/services/pomodoro.py
+++ b/goal_glide/services/pomodoro.py
@@ -96,11 +96,8 @@ def load_active_session() -> Optional[ActiveSession]:
     data = _load_data()
     if data is None:
         return None
-    last_start = (
-        datetime.fromisoformat(data["last_start"])
-        if data.get("last_start")
-        else None
-    )
+    raw_last = data.get("last_start")
+    last_start = datetime.fromisoformat(raw_last) if raw_last is not None else None
     return ActiveSession(
         goal_id=data.get("goal_id"),
         start=datetime.fromisoformat(data["start"]),


### PR DESCRIPTION
## Summary
- define `ConfigDict` for config module
- use `SessionData` TypedDict in pomodoro service
- add `AppContext` TypedDict for CLI context
- introduce typed TinyDB row dictionaries in `Storage`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684533451cb08322ae9d424947b2cd86