### PR TITLE
Add report CLI usage error tests

### DIFF
--- a/tests/test_report_cli.py
+++ b/tests/test_report_cli.py
@@ -119,3 +119,20 @@ def test_cli_range_flags(
     )
     assert result.exit_code == 0
     assert captured == [expected]
+
+
+@pytest.mark.parametrize(
+    "args, msg",
+    [
+        (["--from", "2023-01-01"], "Specify both --from and --to"),
+        (["--to", "2023-01-01"], "Specify both --from and --to"),
+        (
+            ["--week", "--from", "2023-01-01", "--to", "2023-01-07"],
+            "--from/--to cannot be combined with range flags",
+        ),
+    ],
+)
+def test_report_make_usage_errors(runner: CliRunner, args: list[str], msg: str) -> None:
+    result = runner.invoke(cli.goal, ["report", "make", *args])
+    assert result.exit_code != 0
+    assert msg in result.output


### PR DESCRIPTION
## Summary
- add tests for missing `--from` or `--to`
- add test for mixing explicit dates with range flag

## Testing
- `black tests/test_report_cli.py`
- `flake8 tests/test_report_cli.py`
- `mypy tests/test_report_cli.py`
- `pytest tests/test_report_cli.py::test_report_make_usage_errors -q`

------
https://chatgpt.com/codex/tasks/task_e_684533e6ecf0832289cd4941dda0dd27