### PR TITLE
Add error-handling CLI tests

### DIFF
--- a/tests/test_cli_error_handler.py
+++ b/tests/test_cli_error_handler.py
@@ -102,3 +102,9 @@ def test_random_expected_error():
     r = CliRunner().invoke(_fake_cmd(exc_cls("x")))
     assert r.exit_code == 1
     assert "Error:" in r.output
+
+
+def test_click_bad_parameter_error():
+    r = CliRunner().invoke(_fake_cmd(click.BadParameter("oops")))
+    assert r.exit_code == 1
+    assert "Error:" in r.output


### PR DESCRIPTION
## Summary
- improve CLI tests for invalid goal IDs and editor edge cases
- extend exception handler tests for click.BadParameter

## Testing
- `pre-commit run --files tests/test_cli.py tests/test_cli_error_handler.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68457c6dc3b08322a18b1d8a42535e12