### PR TITLE
Add test for HTML top goals limit

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -76,6 +76,29 @@ files = [
 dev = ["backports.zoneinfo ; python_version < \"3.9\"", "freezegun (>=1.0,<2.0)", "jinja2 (>=3.0)", "pytest (>=6.0)", "pytest-cov", "pytz", "setuptools", "tzdata ; sys_platform == \"win32\""]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.13.4"
+description = "Screen-scraping library"
+optional = false
+python-versions = ">=3.7.0"
+groups = ["dev"]
+files = [
+    {file = "beautifulsoup4-4.13.4-py3-none-any.whl", hash = "sha256:9bbbb14bfde9d79f38b8cd5f8c7c85f4b8f2523190ebed90e950a8dea4cb1c4b"},
+    {file = "beautifulsoup4-4.13.4.tar.gz", hash = "sha256:dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195"},
+]
+
+[package.dependencies]
+soupsieve = ">1.2"
+typing-extensions = ">=4.0.0"
+
+[package.extras]
+cchardet = ["cchardet"]
+chardet = ["chardet"]
+charset-normalizer = ["charset-normalizer"]
+html5lib = ["html5lib"]
+lxml = ["lxml"]
+
+[[package]]
 name = "certifi"
 version = "2025.4.26"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -1010,6 +1033,18 @@ files = [
 ]
 
 [[package]]
+name = "soupsieve"
+version = "2.7"
+description = "A modern CSS selector implementation for Beautiful Soup."
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "soupsieve-2.7-py3-none-any.whl", hash = "sha256:6e60cc5c1ffaf1cebcc12e8188320b72071e922c2e897f737cadce79ad5d30c4"},
+    {file = "soupsieve-2.7.tar.gz", hash = "sha256:ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a"},
+]
+
+[[package]]
 name = "sphinx"
 version = "8.2.3"
 description = "Python documentation generator"
@@ -1256,4 +1291,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "6284805591dd4ecc023741534e6e0f9807d5090e261d8a5f157b09a64445c4b0"
+content-hash = "f2b8cae91de35d6125677908dbf29027706625eb0010fa28e51ebca3066dc246"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ pytest-cov = "*"
 hypothesis = "*"
 mypy = "*"
 sphinx = "*"
+beautifulsoup4 = "*"
 
 [tool.black]
 target-version = ['py311']

--- a/tests/test_report_service.py
+++ b/tests/test_report_service.py
@@ -62,7 +62,10 @@ def seed_many(storage: Storage) -> None:
             PomodoroSession(
                 id=f"s{i}",
                 goal_id=gid,
-                start=datetime.combine(week_start + timedelta(days=i - 1), datetime.min.time()),
+                start=datetime.combine(
+                    week_start + timedelta(days=i - 1),
+                    datetime.min.time(),
+                ),
                 duration_sec=dur,
             )
         )

--- a/tests/test_report_service.py
+++ b/tests/test_report_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import date, datetime, timedelta
 from pathlib import Path
+from bs4 import BeautifulSoup
 
 import pandas as pd
 import pytest
@@ -49,6 +50,22 @@ def seed(storage: Storage) -> None:
             duration_sec=1800,
         )
     )
+
+
+def seed_many(storage: Storage) -> None:
+    week_start = FakeDate.today() - timedelta(days=FakeDate.today().weekday())
+    durations = [600, 1200, 1800, 2400, 3000, 3600]
+    for i, dur in enumerate(durations, start=1):
+        gid = f"g{i}"
+        storage.add_goal(Goal(id=gid, title=f"G{i}", created=datetime(2023, 6, 1)))
+        storage.add_session(
+            PomodoroSession(
+                id=f"s{i}",
+                goal_id=gid,
+                start=datetime.combine(week_start + timedelta(days=i - 1), datetime.min.time()),
+                duration_sec=dur,
+            )
+        )
 
 
 def test_date_window_week_month_all(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -187,3 +204,18 @@ def test_custom_range_skips_date_window(
     )
     text = out.read_text()
     assert f"Period: {start} - {end}" in text
+
+
+def test_html_top_goals_limit_and_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(report, "date", FakeDate)
+    storage = Storage(tmp_path)
+    seed_many(storage)
+    out = report.build_report(storage, "week", "html", tmp_path / "top.html")
+    soup = BeautifulSoup(out.read_text(), "html.parser")
+    table = soup.find("h2", string="Top Goals").find_next("table")
+    rows = table.find_all("tr")[1:]
+    assert len(rows) == 5
+    secs = [int(r.find_all("td")[1].text) for r in rows]
+    assert secs == sorted(secs, reverse=True)


### PR DESCRIPTION
## Summary
- install BeautifulSoup for parsing reports in tests
- write seed helper for multiple goals
- ensure HTML report shows only top five goals

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68457f534ce4832284a58e9d5b26c92a