### PR TITLE
Fix reminder status output

### DIFF
--- a/goal_glide/cli.py
+++ b/goal_glide/cli.py
@@ -529,10 +529,6 @@ def reminder_status(ctx: click.Context) -> None:
     interval_min = cfg.get("reminder_interval_min", 30)
     console.print(
         f"Enabled: {enabled} | Break: {break_min}m | Interval: {interval_min}m"
-        "Enabled: "
-        f"{cfg.get('reminders_enabled', False)} | "
-        f"Break: {cfg.get('reminder_break_min', 5)}m | "
-        f"Interval: {cfg.get('reminder_interval_min', 30)}m"
     )
 
 


### PR DESCRIPTION
## Summary
- ensure `reminder status` prints a single formatted line

## Testing
- `pytest tests/test_reminder.py::test_reminder_status_output -q`

------
https://chatgpt.com/codex/tasks/task_e_684623b8de9483228af687dbeb1fad8f