### PR TITLE
Refine exception handling

### DIFF
--- a/goal_glide/cli.py
+++ b/goal_glide/cli.py
@@ -17,13 +17,7 @@ from rich.tree import Tree
 from tinydb import Query
 
 from .config import ConfigDict, load_config, save_config
-from .exceptions import (
-    GoalAlreadyArchivedError,
-    GoalGlideError,
-    GoalNotArchivedError,
-    GoalNotFoundError,
-    InvalidTagError,
-)
+from .exceptions import GoalGlideError
 from .models.goal import Goal, Priority
 from .models.storage import Storage
 from .models.thought import Thought

--- a/goal_glide/exceptions.py
+++ b/goal_glide/exceptions.py
@@ -1,14 +1,29 @@
-class GoalNotFoundError(ValueError):
+
+class GoalGlideError(Exception):
+    """Base exception for all application-specific errors."""
+
     pass
 
 
-class GoalAlreadyArchivedError(ValueError):
+class GoalNotFoundError(GoalGlideError):
+    """Raised when a goal with the given ID is not found."""
+
     pass
 
 
-class GoalNotArchivedError(ValueError):
+class GoalAlreadyArchivedError(GoalGlideError):
+    """Raised when attempting to archive an already-archived goal."""
+
     pass
 
 
-class InvalidTagError(ValueError):
+class GoalNotArchivedError(GoalGlideError):
+    """Raised when attempting to restore a goal that is not archived."""
+
+    pass
+
+
+class InvalidTagError(GoalGlideError):
+    """Raised when a tag format is invalid."""
+
     pass

--- a/tests/test_cli_error_handler.py
+++ b/tests/test_cli_error_handler.py
@@ -32,7 +32,7 @@ def test_expected_error():
 def test_unexpected_error():
     r = CliRunner().invoke(_fake_cmd(RuntimeError("boom")))
     assert r.exit_code == 1
-    assert "Error:" in r.output
+    assert "unexpected" in r.output.lower()
 
 
 @pytest.mark.parametrize(
@@ -52,8 +52,6 @@ def test_really_unexpected_error(exc):
         GoalNotArchivedError("b"),
         InvalidTagError("c"),
         click.ClickException("bad"),
-        RuntimeError("boom"),
-        ValueError("val"),
     ],
 )
 def test_all_expected_errors(exc):
@@ -99,8 +97,6 @@ def test_random_expected_error():
             GoalNotArchivedError,
             InvalidTagError,
             click.ClickException,
-            RuntimeError,
-            ValueError,
         ]
     )
     r = CliRunner().invoke(_fake_cmd(exc_cls("x")))
@@ -117,5 +113,5 @@ def test_click_bad_parameter_error():
 @pytest.mark.parametrize("exc", [KeyboardInterrupt()])
 def test_keyboard_interrupt_unexpected(exc):
     r = CliRunner().invoke(_fake_cmd(exc))
-    assert r.exit_code == 1
+    assert r.exit_code == 130
     assert "aborted" in r.output.lower()

--- a/tests/test_pomo_quotes.py
+++ b/tests/test_pomo_quotes.py
@@ -68,7 +68,7 @@ def test_quote_exception_handling(
     runner.invoke(cli.goal, ["pomo", "start", "--duration", "1"])
     result = runner.invoke(cli.goal, ["pomo", "stop"])
     assert result.exit_code == 1
-    assert "Error:" in result.output
+    assert "unexpected" in result.output.lower()
 
 
 def test_quotes_default_enabled(


### PR DESCRIPTION
## Summary
- add `GoalGlideError` base exception and use it
- refine `handle_exceptions` to separate domain and unexpected failures
- update CLI error handler tests to match new behavior
- update quote service test for unexpected errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684629c7108c8322bf366830f244cfa5