### PR TITLE
Add GOAL_GLIDE_CONFIG_DIR support

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ The HTML and Markdown templates used for report generation live in `goal_glide/t
 
 Data is stored by default in `~/.goal_glide/db.json`. To use a different location set the `GOAL_GLIDE_DB_DIR` environment variable.
 
-Configuration is kept in `~/.goal_glide/config.toml` and controls:
+Configuration is kept in `~/.goal_glide/config.toml`. Set `GOAL_GLIDE_CONFIG_DIR` to override this path. The file controls:
 
 - `quotes_enabled` – show a motivational quote after each session
 - `reminders_enabled` – schedule desktop reminders

--- a/goal_glide/config.py
+++ b/goal_glide/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import tomllib
 from pathlib import Path
+import os
 from typing import Any, Dict, TypedDict, cast
 
 
@@ -19,7 +20,11 @@ DEFAULTS: ConfigDict = {
     "reminder_interval_min": 30,
 }
 
-_CONFIG_PATH = Path.home() / ".goal_glide" / "config.toml"
+_CONFIG_PATH = (
+    Path(os.environ["GOAL_GLIDE_CONFIG_DIR"]) / "config.toml"
+    if "GOAL_GLIDE_CONFIG_DIR" in os.environ
+    else Path.home() / ".goal_glide" / "config.toml"
+)
 
 
 def _load_file() -> Dict[str, Any]:

--- a/tests/test_config_module.py
+++ b/tests/test_config_module.py
@@ -115,3 +115,15 @@ def test_invalid_toml_raises_decode_error(cfg_path: Path) -> None:
     cfg_path.write_text("foo = bar", encoding="utf-8")
     with pytest.raises(tomllib.TOMLDecodeError):
         config.load_config()
+
+
+def test_config_path_from_env(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("GOAL_GLIDE_CONFIG_DIR", str(tmp_path))
+    import importlib
+    import goal_glide.config as cfg
+
+    importlib.reload(cfg)
+    assert cfg._CONFIG_PATH == tmp_path / "config.toml"
+
+    monkeypatch.delenv("GOAL_GLIDE_CONFIG_DIR", raising=False)
+    importlib.reload(cfg)


### PR DESCRIPTION
## Summary
- allow overriding config path with `GOAL_GLIDE_CONFIG_DIR`
- document the new environment variable
- test that config path picks up the env var

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68463bcd616c8322a95927eca2553237