### PR TITLE
Add configurable pomodoro duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ python -m goal_glide list --tag writing
 Start and stop a session (optionally linking it to a goal):
 
 ```bash
-python -m goal_glide pomo start --duration 25 --goal <goal-id>
+python -m goal_glide pomo start --goal <goal-id>
 python -m goal_glide pomo stop
 ```
 The `--goal` flag records the session against the specified goal for
@@ -170,7 +170,7 @@ Quick examples of common commands:
   ```
 - **pomo start/stop** – run a pomodoro timer.
   ```bash
-  python -m goal_glide pomo start --duration 25
+  python -m goal_glide pomo start
   python -m goal_glide pomo stop
   ```
 - **reminder enable/disable** – toggle desktop reminders.
@@ -219,6 +219,7 @@ Configuration is kept in `~/.goal_glide/config.toml`. Set `GOAL_GLIDE_CONFIG_DIR
 - `reminders_enabled` – schedule desktop reminders
 - `reminder_break_min` – length of the break after a pomodoro
 - `reminder_interval_min` – how often to prompt for another session
+- `pomo_duration_min` – default pomodoro duration
 
 Run `python -m goal_glide config quotes --enable/--disable` or the reminder commands shown above to modify these settings.
 Run `python -m goal_glide config show` to view the current configuration.

--- a/goal_glide/cli.py
+++ b/goal_glide/cli.py
@@ -17,6 +17,7 @@ from rich.tree import Tree
 from tinydb import Query
 
 from .config import ConfigDict, load_config, save_config
+from . import config as cfg
 from .exceptions import GoalGlideError
 from .models.goal import Goal, Priority
 from .models.storage import Storage
@@ -408,12 +409,21 @@ def pomo() -> None:
 
 
 @pomo.command("start")
-@click.option("--duration", type=int, default=25, show_default=True, help="Minutes")
+@click.option(
+    "--duration",
+    type=int,
+    default=None,
+    show_default=False,
+    help="Minutes (defaults to config)",
+)
 @click.option("-g", "--goal", "goal_id", help="Associate with goal ID")
 @handle_exceptions
-def start_pomo(duration: int, goal_id: str | None) -> None:
-    start_session(duration, goal_id)
-    console.print(f"Started pomodoro for {duration}m")
+def start_pomo(duration: int | None, goal_id: str | None) -> None:
+    dur = duration
+    if dur is None:
+        dur = cfg.pomo_duration()
+    start_session(dur, goal_id)
+    console.print(f"Started pomodoro for {dur}m")
 
 
 @pomo.command("stop")

--- a/goal_glide/config.py
+++ b/goal_glide/config.py
@@ -11,6 +11,7 @@ class ConfigDict(TypedDict, total=False):
     reminders_enabled: bool
     reminder_break_min: int
     reminder_interval_min: int
+    pomo_duration_min: int
 
 
 DEFAULTS: ConfigDict = {
@@ -18,6 +19,7 @@ DEFAULTS: ConfigDict = {
     "reminders_enabled": False,
     "reminder_break_min": 5,
     "reminder_interval_min": 30,
+    "pomo_duration_min": 25,
 }
 
 _CONFIG_PATH = (
@@ -54,6 +56,10 @@ def reminder_break() -> int:
 
 def reminder_interval() -> int:
     return int(_config().get("reminder_interval_min", 30))
+
+
+def pomo_duration() -> int:
+    return int(_config().get("pomo_duration_min", 25))
 
 
 def load_config() -> ConfigDict:

--- a/goal_glide/services/pomodoro.py
+++ b/goal_glide/services/pomodoro.py
@@ -57,14 +57,15 @@ def _save_data(data: SessionData) -> None:
 
 
 def start_session(
-    duration_min: int = 25,
+    duration_min: int | None = None,
     goal_id: str | None = None,
 ) -> PomodoroSession:
+    dur = duration_min if duration_min is not None else config.pomo_duration()
     session = PomodoroSession(
         id="",
         goal_id=goal_id,
         start=datetime.now(),
-        duration_sec=duration_min * 60,
+        duration_sec=dur * 60,
     )
     data: SessionData = {
         "start": session.start.isoformat(),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -171,7 +171,11 @@ def test_pomo_start_default_from_config(tmp_path, monkeypatch):
     pomodoro.POMO_PATH = tmp_path / "session.json"
     monkeypatch.setattr(config, "pomo_duration", lambda: 2)
     runner = CliRunner()
-    result = runner.invoke(cli.goal, ["pomo", "start"], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)})
+    result = runner.invoke(
+        cli.goal,
+        ["pomo", "start"],
+        env={"GOAL_GLIDE_DB_DIR": str(tmp_path)},
+    )
     assert result.exit_code == 0
     data = json.loads((tmp_path / "session.json").read_text())
     assert data["duration_sec"] == 120

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 from click.testing import CliRunner
 import click
 import pytest
+import json
 
 import goal_glide.cli as cli
 from goal_glide import config
@@ -162,3 +163,15 @@ def test_pomo_start_after_archive(tmp_path, monkeypatch):
     )
     assert start.exit_code == 0
     assert "Started pomodoro" in start.output
+
+
+def test_pomo_start_default_from_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    pomodoro.POMO_PATH = tmp_path / "session.json"
+    monkeypatch.setattr(config, "pomo_duration", lambda: 2)
+    runner = CliRunner()
+    result = runner.invoke(cli.goal, ["pomo", "start"], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)})
+    assert result.exit_code == 0
+    data = json.loads((tmp_path / "session.json").read_text())
+    assert data["duration_sec"] == 120

--- a/tests/test_config_module.py
+++ b/tests/test_config_module.py
@@ -20,6 +20,7 @@ def test_default_values_when_file_missing(cfg_path: Path) -> None:
     assert config.reminders_enabled() is False
     assert config.reminder_break() == 5
     assert config.reminder_interval() == 30
+    assert config.pomo_duration() == 25
     assert config.load_config() == config.DEFAULTS
 
 
@@ -29,6 +30,7 @@ def test_save_and_load_roundtrip(cfg_path: Path) -> None:
         "reminders_enabled": True,
         "reminder_break_min": 10,
         "reminder_interval_min": 20,
+        "pomo_duration_min": 15,
     }
     config.save_config(new_cfg)
     loaded = config.load_config()
@@ -45,6 +47,7 @@ def test_show_command_outputs_all_settings(cfg_path: Path) -> None:
         "reminders_enabled": True,
         "reminder_break_min": 10,
         "reminder_interval_min": 20,
+        "pomo_duration_min": 15,
     }
     config.save_config(cfg)
     runner = CliRunner()
@@ -67,6 +70,7 @@ def test_partial_config_file_loads_defaults(cfg_path: Path) -> None:
     assert config.reminders_enabled() is config.DEFAULTS["reminders_enabled"]
     assert config.reminder_break() == config.DEFAULTS["reminder_break_min"]
     assert config.reminder_interval() == config.DEFAULTS["reminder_interval_min"]
+    assert config.pomo_duration() == config.DEFAULTS["pomo_duration_min"]
 
 
 def test_load_reflects_file_changes(cfg_path: Path) -> None:
@@ -101,6 +105,7 @@ def test_mutating_loaded_config_does_not_affect_cache(cfg_path: Path) -> None:
         "reminders_enabled": True,
         "reminder_break_min": 10,
         "reminder_interval_min": 20,
+        "pomo_duration_min": 15,
     }
     config.save_config(cfg)
 

--- a/tests/test_pomodoro_service.py
+++ b/tests/test_pomodoro_service.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from goal_glide.services import pomodoro
+from goal_glide import config
 
 
 @pytest.fixture()
@@ -87,3 +88,11 @@ def test_pause_resume_flow(monkeypatch: pytest.MonkeyPatch, session_path: Path) 
     twelve = start + timedelta(minutes=12)
     _patch_now(monkeypatch, twelve)
     pomodoro.stop_session()
+
+
+def test_start_session_uses_config_default(
+    monkeypatch: pytest.MonkeyPatch, session_path: Path
+) -> None:
+    monkeypatch.setattr(config, "pomo_duration", lambda: 3)
+    session = pomodoro.start_session()
+    assert session.duration_sec == 180


### PR DESCRIPTION
## Summary
- add `pomo_duration_min` to config with default 25
- use config value when starting pomodoro sessions
- document new configuration option
- update CLI defaults
- test new behaviour

## Testing
- `pip install hypothesis rich tinydb requests apscheduler notify2 textual jinja2 pandas pytest pytest-cov sphinx beautifulsoup4 types-requests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846459b74e88322a72f2a8c452af1f8