### PR TITLE
Add version command

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,10 @@ Quick examples of common commands:
   python -m goal_glide report make --week
   ```
   Use `--from` and `--to` to generate a report for a custom date range.
+- **version** – display package version.
+  ```bash
+  python -m goal_glide version
+  ```
 
 ## Reports
 

--- a/goal_glide/__init__.py
+++ b/goal_glide/__init__.py
@@ -1,3 +1,24 @@
-from .cli import handle_exceptions  # noqa: F401
+"""Goal Glide package."""
 
-__all__ = ["handle_exceptions"]
+from __future__ import annotations
+
+from importlib import metadata
+from pathlib import Path
+import tomllib
+
+
+try:
+    __version__ = metadata.version("goal_glide")
+except metadata.PackageNotFoundError:
+    # Fallback for editable/checkout usage
+    try:
+        pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+        with pyproject.open("rb") as fh:
+            data = tomllib.load(fh)
+        __version__ = data.get("tool", {}).get("poetry", {}).get("version", "0.0.0")
+    except Exception:  # pragma: no cover - extremely unlikely
+        __version__ = "0.0.0"
+
+from .cli import handle_exceptions  # noqa: E402,F401  keep import order
+
+__all__ = ["handle_exceptions", "__version__"]

--- a/goal_glide/cli.py
+++ b/goal_glide/cli.py
@@ -400,6 +400,14 @@ def goal_tree(ctx: click.Context) -> None:
     console.print(tree)
 
 
+@goal.command("version")
+def version_cmd() -> None:
+    """Print package version."""
+    from . import __version__
+
+    console.print(__version__)
+
+
 cli = goal
 
 

--- a/tests/test_version_cmd.py
+++ b/tests/test_version_cmd.py
@@ -1,0 +1,10 @@
+from click.testing import CliRunner
+
+from goal_glide import __version__, cli
+
+
+def test_version_command_outputs_package_version() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli.goal, ["version"])
+    assert result.exit_code == 0
+    assert __version__ in result.output


### PR DESCRIPTION
## Summary
- add package version constant
- print version via new `goal version` command
- document the command in README
- test the version output

## Testing
- `pytest tests/test_version_cmd.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68464fae1fdc8322b17b128622a1fc9c