### PR TITLE
Add CLI/TUI/API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ issues are caught early.
 
 ## Documentation
 
-Sphinx configuration files live in the `docs` directory. Run `make html` inside that folder to build the HTML docs.
+Sphinx configuration files live in the `docs` directory. Run `make html` inside that folder to build the HTML docs. The full manual with command examples, TUI key bindings and API documentation is available there. See [`docs/cli.rst`](docs/cli.rst), [`docs/tui.rst`](docs/tui.rst) and [`docs/api.rst`](docs/api.rst) for the individual sections.
 
 ---
 Goal Glide is distributed under the terms of the GNU General Public License v3.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,17 @@
+API Reference
+=============
+
+.. automodule:: goal_glide.cli
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: goal_glide.tui
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: goal_glide.services.pomodoro
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,45 @@
+Command Line Interface
+======================
+
+The ``goal_glide`` command provides a collection of subcommands for
+managing goals, thoughts and pomodoro sessions.  Below are some common
+command sequences.
+
+Add a new goal with high priority and a deadline::
+
+   python -m goal_glide add "Write blog post" --priority high --deadline 2024-12-01
+
+List all active goals::
+
+   python -m goal_glide list
+
+Archive an old goal and later restore it::
+
+   python -m goal_glide archive <goal-id>
+   python -m goal_glide restore <goal-id>
+
+Start a pomodoro linked to a specific goal::
+
+   python -m goal_glide pomo start --goal <goal-id>
+   python -m goal_glide pomo stop
+
+Key options
+-----------
+
+``--priority``
+    One of ``low``, ``medium`` or ``high`` (defaults to ``medium``).
+
+``--deadline``
+    Optional due date in ``YYYY-MM-DD`` format shown in the TUI when
+    approaching or past due.
+
+``--tag``
+    Add one or more tags to a goal for later filtering, e.g.
+    ``goal_glide tag add <goal-id> work personal``.
+
+``--goal``
+    When starting a pomodoro this records the session against the goal so
+    statistics can be generated later.
+
+Run ``python -m goal_glide --help`` for a full list of commands and
+options.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,22 @@
 project = 'Goal Glide'
 author = 'Goal Glide Developers'
 
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon']
+autodoc_mock_imports = [
+    'click',
+    'rich',
+    'tinydb',
+    'requests',
+    'apscheduler',
+    'notify2',
+    'textual',
+    'jinja2',
+    'pandas',
+]
 
 templates_path = ['_templates']
 exclude_patterns = []

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,3 +9,11 @@ This documentation is generated using Sphinx. To build the HTML pages run:
    make html
 
 The built documentation will be available under ``_build/html``.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   cli
+   tui
+   api

--- a/docs/tui.rst
+++ b/docs/tui.rst
@@ -1,0 +1,40 @@
+Text User Interface
+===================
+
+Goal Glide includes a simple TUI built with Textual. Launch it with::
+
+   python -m goal_glide tui
+
+Navigation and key bindings
+---------------------------
+
+``a``
+    Add a new goal.
+
+``delete``
+    Archive the selected goal.
+
+``s``
+    Start or stop a pomodoro timer for the highlighted goal.
+
+``t``
+    Jot a quick thought linked to the goal.
+
+``e``
+    Edit the selected goal.
+
+``q``
+    Quit the interface.
+
+Workflow example
+----------------
+
+::
+
+   + Goals
+   |-- Write blog post
+   |-- Exercise daily
+
+Use the arrow keys to move through the tree of goals. Press ``s`` to
+start tracking a pomodoro for the highlighted goal. While the timer is
+running a progress bar is shown in the details panel.


### PR DESCRIPTION
## Summary
- add CLI, TUI and API docs
- link new docs in index and README
- enable autodoc imports in Sphinx config

## Testing
- `sphinx-build -M html docs docs/_build`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_68465f641e648322b99f2fee9a57ce03