### PR TITLE
Add GOAL_GLIDE_SESSION_FILE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,9 @@ The HTML and Markdown templates used for report generation live in `goal_glide/t
 
 Data is stored by default in `~/.goal_glide/db.json`. To use a different location set the `GOAL_GLIDE_DB_DIR` environment variable.
 
+Active pomodoro session data is written to `~/.goal_glide/session.json`. Set
+`GOAL_GLIDE_SESSION_FILE` to override this file path.
+
 Configuration is kept in `~/.goal_glide/config.toml`. Set `GOAL_GLIDE_CONFIG_DIR` to override this path. The file controls:
 
 - `quotes_enabled` – show a motivational quote after each session

--- a/goal_glide/services/pomodoro.py
+++ b/goal_glide/services/pomodoro.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Callable, Optional, TypedDict, cast
 
 from rich.console import Console
+import os
 
 from .. import config
 from ..models.session import PomodoroSession
@@ -16,7 +17,12 @@ console = Console()
 on_new_session: list[Callable[[], None]] = []
 on_session_end: list[Callable[[], None]] = []
 
-POMO_PATH = Path.home() / ".goal_glide" / "session.json"
+POMO_PATH = Path(
+    os.environ.get(
+        "GOAL_GLIDE_SESSION_FILE",
+        Path.home() / ".goal_glide" / "session.json",
+    )
+)
 
 
 @dataclass(slots=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,7 +36,9 @@ def test_add_list_remove(tmp_path):
 def test_pomo_session_persisted(tmp_path, monkeypatch):
     monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
     monkeypatch.setenv("HOME", str(tmp_path))
-    pomodoro.POMO_PATH = tmp_path / "session.json"
+    monkeypatch.setenv("GOAL_GLIDE_SESSION_FILE", str(tmp_path / "session.json"))
+    import importlib
+    importlib.reload(pomodoro)
     runner = CliRunner()
     res = runner.invoke(
         cli.goal, ["add", "G"], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)}
@@ -70,7 +72,9 @@ def test_pomo_session_persisted(tmp_path, monkeypatch):
 def test_pomo_pause_resume(tmp_path, monkeypatch):
     monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
     monkeypatch.setenv("HOME", str(tmp_path))
-    pomodoro.POMO_PATH = tmp_path / "session.json"
+    monkeypatch.setenv("GOAL_GLIDE_SESSION_FILE", str(tmp_path / "session.json"))
+    import importlib
+    importlib.reload(pomodoro)
     runner = CliRunner()
     runner.invoke(cli.goal, ["pomo", "start", "--duration", "1"])
     res = runner.invoke(cli.goal, ["pomo", "pause"])
@@ -147,7 +151,9 @@ def test_config_quotes_enable(tmp_path, monkeypatch):
 def test_pomo_start_after_archive(tmp_path, monkeypatch):
     monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
     monkeypatch.setenv("HOME", str(tmp_path))
-    pomodoro.POMO_PATH = tmp_path / "session.json"
+    monkeypatch.setenv("GOAL_GLIDE_SESSION_FILE", str(tmp_path / "session.json"))
+    import importlib
+    importlib.reload(pomodoro)
     runner = CliRunner()
     add_res = runner.invoke(
         cli.goal,
@@ -168,7 +174,9 @@ def test_pomo_start_after_archive(tmp_path, monkeypatch):
 def test_pomo_start_default_from_config(tmp_path, monkeypatch):
     monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
     monkeypatch.setenv("HOME", str(tmp_path))
-    pomodoro.POMO_PATH = tmp_path / "session.json"
+    monkeypatch.setenv("GOAL_GLIDE_SESSION_FILE", str(tmp_path / "session.json"))
+    import importlib
+    importlib.reload(pomodoro)
     monkeypatch.setattr(config, "pomo_duration", lambda: 2)
     runner = CliRunner()
     result = runner.invoke(

--- a/tests/test_pomo_reminder_flow.py
+++ b/tests/test_pomo_reminder_flow.py
@@ -32,6 +32,10 @@ def runner(
 ) -> tuple[CliRunner, list[str]]:
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
+    monkeypatch.setenv("GOAL_GLIDE_SESSION_FILE", str(tmp_path / "session.json"))
+    import importlib
+    importlib.reload(pomodoro)
+    importlib.reload(reminder)
     cfg._CONFIG_PATH = tmp_path / ".goal_glide" / "config.toml"
     monkeypatch.setattr(reminder, "_sched", FakeScheduler())
 
@@ -89,8 +93,6 @@ def test_cancel_all_runs_on_new_session(runner, monkeypatch, tmp_path) -> None:
     sched.add_job(lambda: None, "interval")  # type: ignore[attr-defined]
     sched.add_job(lambda: None, "interval")  # type: ignore[attr-defined]
     assert len(sched.jobs) == 2  # type: ignore[attr-defined]
-
-    monkeypatch.setattr(pomodoro, "POMO_PATH", tmp_path / "session.json")
 
     pomodoro.start_session(1)
 

--- a/tests/test_pomo_status.py
+++ b/tests/test_pomo_status.py
@@ -10,7 +10,9 @@ from goal_glide.services import pomodoro
 def test_status_no_session(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
-    pomodoro.POMO_PATH = tmp_path / "session.json"
+    monkeypatch.setenv("GOAL_GLIDE_SESSION_FILE", str(tmp_path / "session.json"))
+    import importlib
+    importlib.reload(pomodoro)
     runner = CliRunner()
     result = runner.invoke(cli.goal, ["pomo", "status"])
     assert result.exit_code == 0
@@ -20,7 +22,9 @@ def test_status_no_session(tmp_path: Path, monkeypatch):
 def test_status_with_session(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
-    pomodoro.POMO_PATH = tmp_path / "session.json"
+    monkeypatch.setenv("GOAL_GLIDE_SESSION_FILE", str(tmp_path / "session.json"))
+    import importlib
+    importlib.reload(pomodoro)
     start_time = datetime.datetime(2023, 1, 1, 12, 0, 0)
 
     class StartDT(datetime.datetime):
@@ -49,7 +53,9 @@ def test_status_with_session(tmp_path: Path, monkeypatch):
 def test_status_paused(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
-    pomodoro.POMO_PATH = tmp_path / "session.json"
+    monkeypatch.setenv("GOAL_GLIDE_SESSION_FILE", str(tmp_path / "session.json"))
+    import importlib
+    importlib.reload(pomodoro)
     start_time = datetime.datetime(2023, 1, 1, 12, 0, 0)
 
     class StartDT(datetime.datetime):

--- a/tests/test_pomodoro_service.py
+++ b/tests/test_pomodoro_service.py
@@ -13,7 +13,9 @@ from goal_glide import config
 @pytest.fixture()
 def session_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     path = tmp_path / "session.json"
-    monkeypatch.setattr(pomodoro, "POMO_PATH", path)
+    monkeypatch.setenv("GOAL_GLIDE_SESSION_FILE", str(path))
+    import importlib
+    importlib.reload(pomodoro)
     return path
 
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -16,7 +16,9 @@ def _setup_textual() -> bool:
 def app_env(monkeypatch, tmp_path):
     monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
     monkeypatch.setenv("HOME", str(tmp_path))
-    pomodoro.POMO_PATH = tmp_path / "session.json"
+    monkeypatch.setenv("GOAL_GLIDE_SESSION_FILE", str(tmp_path / "session.json"))
+    import importlib
+    importlib.reload(pomodoro)
     yield
 
 


### PR DESCRIPTION
## Summary
- support custom session file path via `GOAL_GLIDE_SESSION_FILE`
- document the new variable in the README
- update tests to set the environment variable and reload modules

## Testing
- `pip install rich click tinydb requests apscheduler notify2 textual jinja2 pandas hypothesis pytest pytest-cov mypy bs4 pandas`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684660fb615c8322acbd3fea7844c2e8