### PR TITLE
Add notification helper hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,15 +242,14 @@ Run `python -m goal_glide config show` to view the current configuration.
 ## Troubleshooting
 
 - **Missing dependencies** – ensure all packages are installed via `poetry install` and that you are using a supported Python version.
-- **No desktop notifications** – install the appropriate helper for your OS. On
-  macOS Goal Glide requires [`terminal-notifier`](https://github.com/julienXX/terminal-notifier)
-  which can be installed with Homebrew:
-  `brew install terminal-notifier`. On Linux it first tries the
+- **No desktop notifications** – if Goal Glide prints a message about installing
+  a helper, follow the instructions for your OS. On macOS install
+  [`terminal-notifier`](https://github.com/julienXX/terminal-notifier) with
+  Homebrew: `brew install terminal-notifier`. On Linux install the
   [`notify2`](https://pypi.org/project/notify2/) Python package
-  (`pip install notify2`) and then falls back to
-  `notify-send` provided by `libnotify-bin` on Debian-based systems
-  (`sudo apt install libnotify-bin`). On Windows the
-  [`win10toast`](https://pypi.org/project/win10toast/) package is used
+  (`pip install notify2`) or `notify-send` from `libnotify-bin`
+  (`sudo apt install libnotify-bin`). On Windows install
+  [`win10toast`](https://pypi.org/project/win10toast/)
   (`pip install win10toast`).
 - **Database not updating** – confirm that `GOAL_GLIDE_DB_DIR` points to a writable directory. A lock file is used to serialise access, so ensure it can be created.
 - **Quotes do not appear** – network access might be blocked. In that case, a local quote database is used automatically.

--- a/goal_glide/services/notify.py
+++ b/goal_glide/services/notify.py
@@ -32,16 +32,32 @@ _OS_NOTIFIERS: dict[str, Callable[[str], None]] = {
     "Windows": _win_notify,
 }
 
+_HELP_HINTS: dict[str, str] = {
+    "Darwin": "Install 'terminal-notifier' with Homebrew: brew install terminal-notifier",
+    "Linux": "Install 'notify2' via pip or 'notify-send' via your package manager",
+    "Windows": "Install 'win10toast' via pip: pip install win10toast",
+}
+
+_DEFAULT_HINT = (
+    "Desktop notifications require an external helper. "
+    "Install 'terminal-notifier' on macOS, 'notify2' or 'notify-send' on Linux, "
+    "or 'win10toast' on Windows."
+)
+
 
 def push(msg: str) -> None:
-    notifier = _OS_NOTIFIERS.get(platform.system())
+    osname = platform.system()
+    notifier = _OS_NOTIFIERS.get(osname)
+    hint = _HELP_HINTS.get(osname, _DEFAULT_HINT)
     if notifier:
         try:
             notifier(msg)
         except Exception as exc:  # pragma: no cover - log only
             logging.warning("Notification failed: %s", exc)
+            print(hint)
     else:  # pragma: no cover - unsupported OS
-        logging.info("No notifier for OS %s", platform.system())
+        logging.info("No notifier for OS %s", osname)
+        print(hint)
 
 
 __all__ = ["push"]

--- a/goal_glide/services/notify.py
+++ b/goal_glide/services/notify.py
@@ -33,7 +33,10 @@ _OS_NOTIFIERS: dict[str, Callable[[str], None]] = {
 }
 
 _HELP_HINTS: dict[str, str] = {
-    "Darwin": "Install 'terminal-notifier' with Homebrew: brew install terminal-notifier",
+    "Darwin": (
+        "Install 'terminal-notifier' with Homebrew: "
+        "brew install terminal-notifier"
+    ),
     "Linux": "Install 'notify2' via pip or 'notify-send' via your package manager",
     "Windows": "Install 'win10toast' via pip: pip install win10toast",
 }

--- a/tests/test_reminder.py
+++ b/tests/test_reminder.py
@@ -149,6 +149,28 @@ def test_notifier_failure_logs_warning(
     assert any("Notification failed" in rec.message for rec in caplog.records)
 
 
+def test_missing_notifier_prints_hint(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(notify.platform, "system", lambda: "UnknownOS")
+    notify.push("msg")
+    captured = capsys.readouterr()
+    assert "terminal-notifier" in captured.out
+
+
+def test_failed_notifier_prints_hint(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def fail(_: str) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setitem(notify._OS_NOTIFIERS, "Linux", fail)
+    monkeypatch.setattr(notify.platform, "system", lambda: "Linux")
+    notify.push("oops")
+    captured = capsys.readouterr()
+    assert "notify2" in captured.out or "notify-send" in captured.out
+
+
 def test_linux_notify_uses_notify2(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[tuple] = []
 


### PR DESCRIPTION
## Summary
- show installation hints when notification helpers are missing or fail
- document notification helper messages in Troubleshooting section
- test console hints for missing notification helpers

## Testing
- `HYPOTHESIS_DEADLINE=0 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68466f3770a48322926770a92723e910