### PR TITLE
Implement dependency injection for file paths

### DIFF
--- a/goal_glide/config.py
+++ b/goal_glide/config.py
@@ -22,54 +22,20 @@ DEFAULTS: ConfigDict = {
     "pomo_duration_min": 25,
 }
 
-_CONFIG_PATH = (
-    Path(os.environ["GOAL_GLIDE_CONFIG_DIR"]) / "config.toml"
-    if "GOAL_GLIDE_CONFIG_DIR" in os.environ
-    else Path.home() / ".goal_glide" / "config.toml"
-)
-
-
-def _load_file() -> Dict[str, Any]:
-    if _CONFIG_PATH.exists():
-        with _CONFIG_PATH.open("rb") as f:
+def _load_file(config_path: Path) -> Dict[str, Any]:
+    if config_path.exists():
+        with config_path.open("rb") as f:
             return tomllib.load(f)
     return {}
 
 
-def _config() -> ConfigDict:
-    data = cast(ConfigDict, _load_file())
-    full_cfg: ConfigDict = {**DEFAULTS, **data}
-    return full_cfg
-
-
-def quotes_enabled() -> bool:
-    return bool(_config().get("quotes_enabled", True))
-
-
-def reminders_enabled() -> bool:
-    return bool(_config().get("reminders_enabled", False))
-
-
-def reminder_break() -> int:
-    return int(_config().get("reminder_break_min", 5))
-
-
-def reminder_interval() -> int:
-    return int(_config().get("reminder_interval_min", 30))
-
-
-def pomo_duration() -> int:
-    return int(_config().get("pomo_duration_min", 25))
-
-
-def load_config() -> ConfigDict:
-    file_cfg = cast(ConfigDict, _load_file())
+def load_config(config_path: Path) -> ConfigDict:
+    file_cfg = cast(ConfigDict, _load_file(config_path))
     full_cfg: ConfigDict = {**DEFAULTS, **file_cfg}
     return full_cfg
 
 
-def save_config(cfg: ConfigDict) -> None:
-    _CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+def save_config(cfg: ConfigDict, config_path: Path) -> None:
     items = []
     for k, v in cfg.items():
         if isinstance(v, bool):
@@ -77,5 +43,25 @@ def save_config(cfg: ConfigDict) -> None:
         else:
             items.append(f"{k} = {v!r}")
     content = "\n".join(items)
-    with _CONFIG_PATH.open("w", encoding="utf-8") as f:
+    with config_path.open("w", encoding="utf-8") as f:
         f.write(content)
+
+
+def quotes_enabled(config_path: Path) -> bool:
+    return bool(load_config(config_path).get("quotes_enabled", True))
+
+
+def reminders_enabled(config_path: Path) -> bool:
+    return bool(load_config(config_path).get("reminders_enabled", False))
+
+
+def reminder_break(config_path: Path) -> int:
+    return int(load_config(config_path).get("reminder_break_min", 5))
+
+
+def reminder_interval(config_path: Path) -> int:
+    return int(load_config(config_path).get("reminder_interval_min", 30))
+
+
+def pomo_duration(config_path: Path) -> int:
+    return int(load_config(config_path).get("pomo_duration_min", 25))

--- a/goal_glide/models/storage.py
+++ b/goal_glide/models/storage.py
@@ -59,10 +59,7 @@ class Storage:
         session_table: Table used for storing pomodoro sessions.
     """
 
-    def __init__(self, db_dir: Path | None = None) -> None:
-        base = db_dir or Path.home() / ".goal_glide"
-        db_path = Path(base) / "db.json"
-        db_path.parent.mkdir(parents=True, exist_ok=True)
+    def __init__(self, db_path: Path) -> None:
         self.lock = FileLock(db_path.with_suffix(".lock"))
         with self.lock:
             self.db = TinyDB(db_path, default=str)

--- a/goal_glide/services/pomodoro.py
+++ b/goal_glide/services/pomodoro.py
@@ -7,8 +7,6 @@ from pathlib import Path
 from typing import Callable, Optional, TypedDict, cast
 
 from rich.console import Console
-import os
-
 from .. import config
 from ..models.session import PomodoroSession
 
@@ -17,12 +15,7 @@ console = Console()
 on_new_session: list[Callable[[], None]] = []
 on_session_end: list[Callable[[], None]] = []
 
-POMO_PATH = Path(
-    os.environ.get(
-        "GOAL_GLIDE_SESSION_FILE",
-        Path.home() / ".goal_glide" / "session.json",
-    )
-)
+
 
 
 @dataclass(slots=True)
@@ -44,10 +37,10 @@ class SessionData(TypedDict):
     last_start: str | None
 
 
-def _load_data() -> SessionData | None:
-    if not POMO_PATH.exists():
+def _load_data(session_path: Path) -> SessionData | None:
+    if not session_path.exists():
         return None
-    with POMO_PATH.open(encoding="utf-8") as fp:
+    with session_path.open(encoding="utf-8") as fp:
         data = cast(SessionData, json.load(fp))
     # backward compatibility for older session files
     data.setdefault("elapsed_sec", 0)
@@ -56,17 +49,18 @@ def _load_data() -> SessionData | None:
     return data
 
 
-def _save_data(data: SessionData) -> None:
-    POMO_PATH.parent.mkdir(parents=True, exist_ok=True)
-    with POMO_PATH.open("w", encoding="utf-8") as fp:
+def _save_data(data: SessionData, session_path: Path) -> None:
+    with session_path.open("w", encoding="utf-8") as fp:
         json.dump(data, fp)
 
 
 def start_session(
-    duration_min: int | None = None,
-    goal_id: str | None = None,
+    duration_min: int | None,
+    goal_id: str | None,
+    session_path: Path,
+    config_path: Path,
 ) -> PomodoroSession:
-    dur = duration_min if duration_min is not None else config.pomo_duration()
+    dur = duration_min if duration_min is not None else config.pomo_duration(config_path)
     session = PomodoroSession(
         id="",
         goal_id=goal_id,
@@ -81,14 +75,14 @@ def start_session(
         "paused": False,
         "last_start": session.start.isoformat(),
     }
-    _save_data(data)
+    _save_data(data, session_path)
     for cb in on_new_session:
         cb()
     return session
 
 
-def load_session() -> Optional[PomodoroSession]:
-    data = _load_data()
+def load_session(session_path: Path) -> Optional[PomodoroSession]:
+    data = _load_data(session_path)
     if data is None:
         return None
     return PomodoroSession(
@@ -99,8 +93,8 @@ def load_session() -> Optional[PomodoroSession]:
     )
 
 
-def load_active_session() -> Optional[ActiveSession]:
-    data = _load_data()
+def load_active_session(session_path: Path) -> Optional[ActiveSession]:
+    data = _load_data(session_path)
     if data is None:
         return None
     raw_last = data.get("last_start")
@@ -115,21 +109,21 @@ def load_active_session() -> Optional[ActiveSession]:
     )
 
 
-def stop_session() -> PomodoroSession:
-    active = load_active_session()
+def stop_session(session_path: Path, config_path: Path) -> PomodoroSession:
+    active = load_active_session(session_path)
     if active is None:
         raise RuntimeError("No active session")
     # update elapsed if still running
     if not active.paused and active.last_start is not None:
         now = datetime.now()
         delta = int((now - active.last_start).total_seconds())
-        data = _load_data() or cast(SessionData, {})
+        data = _load_data(session_path) or cast(SessionData, {})
         data["elapsed_sec"] = active.elapsed_sec + delta
-        _save_data(data)
-    POMO_PATH.unlink(missing_ok=True)
+        _save_data(data, session_path)
+    session_path.unlink(missing_ok=True)
     for cb in on_session_end:
         cb()
-    if config.reminders_enabled():
+    if config.reminders_enabled(config_path):
         console.print(":bell:  Break & interval reminders scheduled.", style="green")
     return PomodoroSession(
         id="",
@@ -139,31 +133,31 @@ def stop_session() -> PomodoroSession:
     )
 
 
-def pause_session() -> ActiveSession:
-    active = load_active_session()
+def pause_session(session_path: Path) -> ActiveSession:
+    active = load_active_session(session_path)
     if active is None:
         raise RuntimeError("No active session")
     if active.paused:
         raise RuntimeError("Session already paused")
     now = datetime.now()
     delta = int((now - active.last_start).total_seconds()) if active.last_start else 0
-    data = _load_data() or cast(SessionData, {})
+    data = _load_data(session_path) or cast(SessionData, {})
     data["elapsed_sec"] = active.elapsed_sec + delta
     data["paused"] = True
     data["last_start"] = None
-    _save_data(data)
-    return load_active_session()  # type: ignore[return-value]
+    _save_data(data, session_path)
+    return load_active_session(session_path)  # type: ignore[return-value]
 
 
-def resume_session() -> ActiveSession:
-    active = load_active_session()
+def resume_session(session_path: Path) -> ActiveSession:
+    active = load_active_session(session_path)
     if active is None:
         raise RuntimeError("No active session")
     if not active.paused:
         raise RuntimeError("Session is not paused")
     now = datetime.now()
-    data = _load_data() or cast(SessionData, {})
+    data = _load_data(session_path) or cast(SessionData, {})
     data["paused"] = False
     data["last_start"] = now.isoformat()
-    _save_data(data)
-    return load_active_session()  # type: ignore[return-value]
+    _save_data(data, session_path)
+    return load_active_session(session_path)  # type: ignore[return-value]

--- a/goal_glide/services/reminder.py
+++ b/goal_glide/services/reminder.py
@@ -19,8 +19,8 @@ def _scheduler() -> BackgroundScheduler:
     return _sched
 
 
-def schedule_after_stop() -> None:
-    if not reminders_enabled():
+def schedule_after_stop(config_path: Path) -> None:
+    if not reminders_enabled(config_path):
         return
     sched = _scheduler()
     sched.remove_all_jobs(jobstore="default")
@@ -28,14 +28,14 @@ def schedule_after_stop() -> None:
     sched.add_job(
         push,
         "date",
-        run_date=now + timedelta(minutes=reminder_break()),
+        run_date=now + timedelta(minutes=reminder_break(config_path)),
         args=["Break over, ready for next session?"],
         id="break_end",
     )
     sched.add_job(
         push,
         "interval",
-        minutes=reminder_interval(),
+        minutes=reminder_interval(config_path),
         args=["Time for another Pomodoro!"],
         id="next_pomo",
     )
@@ -46,7 +46,6 @@ def cancel_all() -> None:
         _sched.remove_all_jobs()
 
 
-pomodoro.on_session_end.append(schedule_after_stop)
 pomodoro.on_new_session.append(cancel_all)
 
 

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -25,7 +25,7 @@ def seed(storage: Storage, sessions: list[PomodoroSession]) -> None:
 
 
 def test_total_time_by_goal_simple(tmp_path: Path) -> None:
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     seed(
         storage,
         [
@@ -41,7 +41,7 @@ def test_total_time_by_goal_simple(tmp_path: Path) -> None:
 
 def test_total_time_by_goal_parent_accum(tmp_path: Path) -> None:
     """Accumulated time propagates through multi-level hierarchies."""
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     grand = Goal(id="gp", title="grand", created=datetime.now())
     parent = Goal(id="p", title="p", created=datetime.now(), parent_id="gp")
     child = Goal(id="c", title="c", created=datetime.now(), parent_id="p")
@@ -61,7 +61,7 @@ def test_total_time_by_goal_parent_accum(tmp_path: Path) -> None:
 
 def test_total_time_by_goal_missing_parent(tmp_path: Path) -> None:
     """Sessions for a child with a missing parent should not error."""
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     child = Goal(id="c", title="c", created=datetime.now(), parent_id="missing")
     storage.add_goal(child)
     storage.add_session(make_session("c", datetime.now(), 40))
@@ -73,7 +73,7 @@ def test_total_time_by_goal_missing_parent(tmp_path: Path) -> None:
 
 def test_weekly_histogram_exact_bounds(tmp_path: Path) -> None:
     today = date(2023, 5, 15)  # Monday
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     seed(
         storage,
         [
@@ -87,12 +87,12 @@ def test_weekly_histogram_exact_bounds(tmp_path: Path) -> None:
 
 
 def test_current_streak_zero(tmp_path: Path) -> None:
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     assert analytics.current_streak(storage, date(2023, 1, 1)) == 0
 
 
 def test_current_streak_nonzero(tmp_path: Path) -> None:
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     seed(
         storage,
         [
@@ -104,7 +104,7 @@ def test_current_streak_nonzero(tmp_path: Path) -> None:
 
 
 def test_empty_storage(tmp_path: Path) -> None:
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     start = date(2023, 1, 2)
     assert analytics.total_time_by_goal(storage) == {}
     assert analytics.weekly_histogram(storage, start) == {
@@ -114,7 +114,7 @@ def test_empty_storage(tmp_path: Path) -> None:
 
 
 def test_total_time_by_goal_ignores_invalid(tmp_path: Path) -> None:
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     sessions = [
         PomodoroSession(
             id="1",
@@ -149,7 +149,7 @@ def test_total_time_by_goal_ignores_invalid(tmp_path: Path) -> None:
 
 def test_weekly_histogram_varied(tmp_path: Path) -> None:
     week_start = date(2023, 5, 15)  # Monday
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     sessions = [
         make_session("g", datetime(2023, 5, 15, 8), 10),
         make_session("g", datetime(2023, 5, 15, 9), 20),
@@ -171,7 +171,7 @@ def test_weekly_histogram_varied(tmp_path: Path) -> None:
 
 def test_current_streak_with_gaps_and_future(tmp_path: Path) -> None:
     today = date(2023, 6, 5)
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     sessions = [
         make_session("g", datetime(2023, 6, 5, 8), 25),
         make_session("g", datetime(2023, 6, 5, 9), 30),  # multiple same day
@@ -185,7 +185,7 @@ def test_current_streak_with_gaps_and_future(tmp_path: Path) -> None:
 
 
 def test_average_focus_per_day_simple(tmp_path: Path) -> None:
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     sessions = [
         make_session("g", datetime(2023, 6, 1, 8), 60),
         make_session("g", datetime(2023, 6, 2, 8), 120),
@@ -196,7 +196,7 @@ def test_average_focus_per_day_simple(tmp_path: Path) -> None:
 
 
 def test_most_productive_day_simple(tmp_path: Path) -> None:
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     sessions = [
         make_session("g", datetime(2023, 6, 1, 8), 60),  # Thu
         make_session("g", datetime(2023, 6, 2, 8), 120),  # Fri
@@ -207,7 +207,7 @@ def test_most_productive_day_simple(tmp_path: Path) -> None:
 
 
 def test_longest_streak_simple(tmp_path: Path) -> None:
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     sessions = [
         make_session("g", datetime(2023, 6, 1, 8), 30),
         make_session("g", datetime(2023, 6, 2, 8), 30),
@@ -221,7 +221,7 @@ def test_longest_streak_simple(tmp_path: Path) -> None:
 
 def test_weekly_histogram_year_boundary(tmp_path: Path) -> None:
     week_start = date(2023, 12, 29)  # Friday spanning new year
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     sessions = [
         make_session("g", datetime(2023, 12, 29, 8), 10),
         make_session("g", datetime(2023, 12, 31, 9), 20),
@@ -236,7 +236,7 @@ def test_weekly_histogram_year_boundary(tmp_path: Path) -> None:
 
 
 def test_current_streak_year_boundary(tmp_path: Path) -> None:
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     sessions = [
         make_session("g", datetime(2023, 12, 31, 8), 15),
         make_session("g", datetime(2024, 1, 1, 8), 15),
@@ -246,7 +246,7 @@ def test_current_streak_year_boundary(tmp_path: Path) -> None:
 
 
 def test_current_streak_adjacent_seconds(tmp_path: Path) -> None:
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     sessions = [
         make_session("g", datetime(2023, 6, 1, 23, 59, 59), 5),
         make_session("g", datetime(2023, 6, 2, 0, 0, 1), 5),
@@ -256,7 +256,7 @@ def test_current_streak_adjacent_seconds(tmp_path: Path) -> None:
 
 
 def test_longest_streak_multiple_equal(tmp_path: Path) -> None:
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     sessions = [
         make_session("g", datetime(2023, 6, 1, 8), 20),
         make_session("g", datetime(2023, 6, 2, 8), 20),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,7 +24,7 @@ def test_add_list_remove(tmp_path):
     assert "Test" in result.output
 
     # remove using id from storage (rich table may truncate id)
-    goal_id = Storage(tmp_path).list_goals()[0].id
+    goal_id = Storage(tmp_path / "db.json").list_goals()[0].id
     result = runner.invoke(
         cli.goal,
         ["remove", goal_id],
@@ -37,9 +37,6 @@ def test_add_list_remove(tmp_path):
 def test_pomo_session_persisted(tmp_path, monkeypatch):
     monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
     monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("GOAL_GLIDE_SESSION_FILE", str(tmp_path / "session.json"))
-    import importlib
-    importlib.reload(pomodoro)
     runner = CliRunner()
     res = runner.invoke(
         cli.goal, ["add", "G"], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)}
@@ -64,7 +61,7 @@ def test_pomo_session_persisted(tmp_path, monkeypatch):
         env={"GOAL_GLIDE_DB_DIR": str(tmp_path)},
     )
     assert paused.exit_code == 1
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     sessions = storage.list_sessions()
     assert len(sessions) == 1
     assert sessions[0].goal_id == gid
@@ -73,9 +70,6 @@ def test_pomo_session_persisted(tmp_path, monkeypatch):
 def test_pomo_pause_resume(tmp_path, monkeypatch):
     monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
     monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("GOAL_GLIDE_SESSION_FILE", str(tmp_path / "session.json"))
-    import importlib
-    importlib.reload(pomodoro)
     runner = CliRunner()
     runner.invoke(cli.goal, ["pomo", "start", "--duration", "1"])
     res = runner.invoke(cli.goal, ["pomo", "pause"])
@@ -92,7 +86,7 @@ def test_jot_from_editor(tmp_path, monkeypatch):
     runner = CliRunner()
     result = runner.invoke(cli.thought, ["jot"])
     assert result.exit_code == 0
-    thought_text = Storage(tmp_path).list_thoughts()[0].text
+    thought_text = Storage(tmp_path / "db.json").list_thoughts()[0].text
     assert thought_text == "note from editor"
 
 
@@ -116,7 +110,7 @@ def test_jot_from_editor_unicode(tmp_path, monkeypatch):
     runner = CliRunner()
     result = runner.invoke(cli.thought, ["jot"])
     assert result.exit_code == 0
-    stored = Storage(tmp_path).list_thoughts()[0].text
+    stored = Storage(tmp_path / "db.json").list_thoughts()[0].text
     assert stored == "Привет мир"
 
 
@@ -127,34 +121,31 @@ def test_jot_from_editor_empty(tmp_path, monkeypatch):
     result = runner.invoke(cli.thought, ["jot"])
     assert result.exit_code == 1
     assert "Error:" in result.output
-    assert Storage(tmp_path).list_thoughts() == []
+    assert Storage(tmp_path / "db.json").list_thoughts() == []
 
 
 def test_config_quotes_disable(tmp_path, monkeypatch):
-    monkeypatch.setattr(config, "_CONFIG_PATH", tmp_path / "config.toml")
+    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
     runner = CliRunner()
-    result = runner.invoke(cli.goal, ["config", "quotes", "--disable"])
+    result = runner.invoke(cli.goal, ["config", "quotes", "--disable"], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)})
     assert result.exit_code == 0
     assert "Quotes are OFF" in result.output
-    assert config.quotes_enabled() is False
+    assert config.quotes_enabled(tmp_path / "config.toml") is False
 
 
 def test_config_quotes_enable(tmp_path, monkeypatch):
-    monkeypatch.setattr(config, "_CONFIG_PATH", tmp_path / "config.toml")
+    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
     runner = CliRunner()
-    runner.invoke(cli.goal, ["config", "quotes", "--disable"])
-    result = runner.invoke(cli.goal, ["config", "quotes", "--enable"])
+    runner.invoke(cli.goal, ["config", "quotes", "--disable"], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)})
+    result = runner.invoke(cli.goal, ["config", "quotes", "--enable"], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)})
     assert result.exit_code == 0
     assert "Quotes are ON" in result.output
-    assert config.quotes_enabled() is True
+    assert config.quotes_enabled(tmp_path / "config.toml") is True
 
 
 def test_pomo_start_after_archive(tmp_path, monkeypatch):
     monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
     monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("GOAL_GLIDE_SESSION_FILE", str(tmp_path / "session.json"))
-    import importlib
-    importlib.reload(pomodoro)
     runner = CliRunner()
     add_res = runner.invoke(
         cli.goal,
@@ -175,9 +166,6 @@ def test_pomo_start_after_archive(tmp_path, monkeypatch):
 def test_pomo_start_default_from_config(tmp_path, monkeypatch):
     monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
     monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("GOAL_GLIDE_SESSION_FILE", str(tmp_path / "session.json"))
-    import importlib
-    importlib.reload(pomodoro)
     monkeypatch.setattr(config, "pomo_duration", lambda: 2)
     runner = CliRunner()
     result = runner.invoke(

--- a/tests/test_goal_archive.py
+++ b/tests/test_goal_archive.py
@@ -24,14 +24,14 @@ def runner(monkeypatch, tmp_path: Path) -> CliRunner:
 def test_add_with_priority(tmp_path: Path, runner: CliRunner) -> None:
     result = runner.invoke(goal, ["add", "Test goal", "-p", "high"])
     assert result.exit_code == 0
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     goals = storage.list_goals()
     assert goals[0].priority == Priority.high
 
 
 def test_add_with_deadline(tmp_path: Path, runner: CliRunner) -> None:
     runner.invoke(goal, ["add", "Test goal", "--deadline", "2030-01-01"])
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     goals = storage.list_goals()
     assert goals[0].deadline.strftime("%Y-%m-%d") == "2030-01-01"
 
@@ -39,25 +39,25 @@ def test_add_with_deadline(tmp_path: Path, runner: CliRunner) -> None:
 def test_archive_sets_flag(tmp_path: Path, runner: CliRunner) -> None:
     result = runner.invoke(goal, ["add", "Test goal"])
     assert result.exit_code == 0
-    goal_id = Storage(tmp_path).list_goals()[0].id
+    goal_id = Storage(tmp_path / "db.json").list_goals()[0].id
     result = runner.invoke(goal, ["archive", goal_id])
     assert result.exit_code == 0
-    assert Storage(tmp_path).get_goal(goal_id).archived is True
+    assert Storage(tmp_path / "db.json").get_goal(goal_id).archived is True
 
 
 def test_restore_unsets_flag(tmp_path: Path, runner: CliRunner) -> None:
     result = runner.invoke(goal, ["add", "Test goal"])
-    gid = Storage(tmp_path).list_goals()[0].id
+    gid = Storage(tmp_path / "db.json").list_goals()[0].id
     runner.invoke(goal, ["archive", gid])
     result = runner.invoke(goal, ["restore", gid])
     assert result.exit_code == 0
-    assert Storage(tmp_path).get_goal(gid).archived is False
+    assert Storage(tmp_path / "db.json").get_goal(gid).archived is False
 
 
 def test_list_filters_priority_and_archived(tmp_path: Path, runner: CliRunner) -> None:
     runner.invoke(goal, ["add", "g1", "-p", "low"])
     runner.invoke(goal, ["add", "g2", "-p", "high"])
-    gid = [g for g in Storage(tmp_path).list_goals() if g.priority == Priority.low][
+    gid = [g for g in Storage(tmp_path / "db.json").list_goals() if g.priority == Priority.low][
         0
     ].id
     runner.invoke(goal, ["archive", gid])
@@ -71,7 +71,7 @@ def test_list_filters_priority_and_archived(tmp_path: Path, runner: CliRunner) -
 
 def test_errors_on_double_archive(tmp_path: Path, runner: CliRunner) -> None:
     runner.invoke(goal, ["add", "g1"])
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     gid = storage.list_goals()[0].id
     runner.invoke(goal, ["archive", gid])
     result = runner.invoke(goal, ["archive", gid])
@@ -81,12 +81,12 @@ def test_errors_on_double_archive(tmp_path: Path, runner: CliRunner) -> None:
 
 def test_archive_restore_keeps_tags(tmp_path: Path, runner: CliRunner) -> None:
     runner.invoke(goal, ["add", "g"])
-    gid = Storage(tmp_path).list_goals()[0].id
+    gid = Storage(tmp_path / "db.json").list_goals()[0].id
     runner.invoke(goal, ["tag", "add", gid, "a", "b"])
     runner.invoke(goal, ["archive", gid])
-    assert Storage(tmp_path).get_goal(gid).tags == ["a", "b"]
+    assert Storage(tmp_path / "db.json").get_goal(gid).tags == ["a", "b"]
     runner.invoke(goal, ["restore", gid])
-    assert Storage(tmp_path).get_goal(gid).tags == ["a", "b"]
+    assert Storage(tmp_path / "db.json").get_goal(gid).tags == ["a", "b"]
 
 
 def test_archive_nonexistent_id(runner: CliRunner) -> None:
@@ -103,7 +103,7 @@ def test_restore_nonexistent_id(runner: CliRunner) -> None:
 
 def test_restore_not_archived(tmp_path: Path, runner: CliRunner) -> None:
     runner.invoke(goal, ["add", "g"])
-    gid = Storage(tmp_path).list_goals()[0].id
+    gid = Storage(tmp_path / "db.json").list_goals()[0].id
     result = runner.invoke(goal, ["restore", gid])
     assert result.exit_code == 1
     assert "not archived" in result.output
@@ -111,7 +111,7 @@ def test_restore_not_archived(tmp_path: Path, runner: CliRunner) -> None:
 
 def test_list_all_includes_archived(tmp_path: Path, runner: CliRunner) -> None:
     runner.invoke(goal, ["add", "g1"])
-    gid1 = Storage(tmp_path).list_goals()[0].id
+    gid1 = Storage(tmp_path / "db.json").list_goals()[0].id
     runner.invoke(goal, ["archive", gid1])
     runner.invoke(goal, ["add", "g2"])
     result = runner.invoke(goal, ["list"])
@@ -124,7 +124,7 @@ def test_list_archived_priority_filter(tmp_path: Path, runner: CliRunner) -> Non
     runner.invoke(goal, ["add", "a", "-p", "low"])
     runner.invoke(goal, ["add", "b", "-p", "high"])
     runner.invoke(goal, ["add", "c", "-p", "low"])
-    goals = Storage(tmp_path).list_goals()
+    goals = Storage(tmp_path / "db.json").list_goals()
     for g in goals:
         runner.invoke(goal, ["archive", g.id])
     result = runner.invoke(goal, ["list", "--archived", "--priority", "high"])
@@ -135,7 +135,7 @@ def test_list_archived_priority_filter(tmp_path: Path, runner: CliRunner) -> Non
 
 def test_list_shows_completed(tmp_path: Path, runner: CliRunner) -> None:
     runner.invoke(goal, ["add", "g"], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)})
-    gid = Storage(tmp_path).list_goals()[0].id
+    gid = Storage(tmp_path / "db.json").list_goals()[0].id
     runner.invoke(goal, ["complete", gid], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)})
     result = runner.invoke(goal, ["list"], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)})
     assert "Comple" in result.output

--- a/tests/test_goal_complete.py
+++ b/tests/test_goal_complete.py
@@ -13,14 +13,14 @@ def runner(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> CliRunner:
 
 def test_complete_and_reopen(tmp_path: Path, runner: CliRunner) -> None:
     runner.invoke(goal, ["add", "g"], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)})
-    gid = Storage(tmp_path).list_goals()[0].id
+    gid = Storage(tmp_path / "db.json").list_goals()[0].id
     result = runner.invoke(
         goal, ["complete", gid], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)}
     )
     assert result.exit_code == 0
-    assert Storage(tmp_path).get_goal(gid).completed is True
+    assert Storage(tmp_path / "db.json").get_goal(gid).completed is True
     result = runner.invoke(
         goal, ["reopen", gid], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)}
     )
     assert result.exit_code == 0
-    assert Storage(tmp_path).get_goal(gid).completed is False
+    assert Storage(tmp_path / "db.json").get_goal(gid).completed is False

--- a/tests/test_goal_subgoals.py
+++ b/tests/test_goal_subgoals.py
@@ -10,7 +10,7 @@ from goal_glide.models.storage import Storage
 
 
 def test_store_and_retrieve_parent(tmp_path: Path) -> None:
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     parent = Goal(id="p", title="parent", created=datetime.utcnow())
     child = Goal(id="c", title="child", created=datetime.utcnow(), parent_id="p")
     storage.add_goal(parent)
@@ -21,7 +21,7 @@ def test_store_and_retrieve_parent(tmp_path: Path) -> None:
 
 
 def test_list_goals_parent_filter(tmp_path: Path) -> None:
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     p = Goal(id="p", title="parent", created=datetime.utcnow())
     child1 = Goal(id="c1", title="child1", created=datetime.utcnow(), parent_id="p")
     child2 = Goal(id="c2", title="child2", created=datetime.utcnow(), parent_id="p")
@@ -34,7 +34,7 @@ def test_list_goals_parent_filter(tmp_path: Path) -> None:
 
 
 def test_remove_parent_keeps_children(tmp_path: Path) -> None:
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     parent = Goal(id="p", title="p", created=datetime.utcnow())
     c1 = Goal(id="c1", title="c1", created=datetime.utcnow(), parent_id="p")
     c2 = Goal(id="c2", title="c2", created=datetime.utcnow(), parent_id="p")
@@ -51,7 +51,7 @@ def test_remove_parent_keeps_children(tmp_path: Path) -> None:
 
 
 def test_list_goals_parent_with_archived_flags(tmp_path: Path) -> None:
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     p = Goal(id="p", title="parent", created=datetime.utcnow())
     active = Goal(id="a", title="active", created=datetime.utcnow(), parent_id="p")
     archived = Goal(id="b", title="archived", created=datetime.utcnow(), parent_id="p")
@@ -71,7 +71,7 @@ def test_list_goals_parent_with_archived_flags(tmp_path: Path) -> None:
 
 
 def test_list_goals_parent_missing_returns_empty(tmp_path: Path) -> None:
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     storage.add_goal(Goal(id="p", title="parent", created=datetime.utcnow()))
     storage.add_goal(
         Goal(id="c", title="child", created=datetime.utcnow(), parent_id="p")
@@ -124,9 +124,9 @@ def test_cli_add_with_parent(tmp_path: Path) -> None:
     runner = CliRunner()
     env = {"GOAL_GLIDE_DB_DIR": str(tmp_path)}
     runner.invoke(goal, ["add", "parent"], env=env)
-    pid = Storage(tmp_path).list_goals()[0].id
+    pid = Storage(tmp_path / "db.json").list_goals()[0].id
     runner.invoke(goal, ["add", "child", "--parent", pid], env=env)
-    children = Storage(tmp_path).list_goals(parent_id=pid)
+    children = Storage(tmp_path / "db.json").list_goals(parent_id=pid)
     assert len(children) == 1 and children[0].title == "child"
 
 
@@ -134,7 +134,7 @@ def test_goal_tree_output(tmp_path: Path) -> None:
     runner = CliRunner()
     env = {"GOAL_GLIDE_DB_DIR": str(tmp_path)}
     runner.invoke(goal, ["add", "parent"], env=env)
-    pid = Storage(tmp_path).list_goals()[0].id
+    pid = Storage(tmp_path / "db.json").list_goals()[0].id
     runner.invoke(goal, ["add", "child", "--parent", pid], env=env)
     result = runner.invoke(goal, ["tree"], env=env)
     assert "child" in result.output

--- a/tests/test_goal_update.py
+++ b/tests/test_goal_update.py
@@ -16,29 +16,29 @@ def runner(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> CliRunner:
 
 def test_update_title(tmp_path: Path, runner: CliRunner) -> None:
     runner.invoke(goal, ["add", "old title"])
-    gid = Storage(tmp_path).list_goals()[0].id
+    gid = Storage(tmp_path / "db.json").list_goals()[0].id
     result = runner.invoke(goal, ["update", gid, "--title", "new title"])
     assert result.exit_code == 0
-    assert Storage(tmp_path).get_goal(gid).title == "new title"
+    assert Storage(tmp_path / "db.json").get_goal(gid).title == "new title"
 
 
 def test_update_priority(tmp_path: Path, runner: CliRunner) -> None:
     runner.invoke(goal, ["add", "g"])
-    gid = Storage(tmp_path).list_goals()[0].id
+    gid = Storage(tmp_path / "db.json").list_goals()[0].id
     result = runner.invoke(goal, ["update", gid, "--priority", "high"])
     assert result.exit_code == 0
-    assert Storage(tmp_path).get_goal(gid).priority == Priority.high
+    assert Storage(tmp_path / "db.json").get_goal(gid).priority == Priority.high
 
 
 def test_update_deadline(tmp_path: Path, runner: CliRunner) -> None:
     runner.invoke(goal, ["add", "g"])
-    gid = Storage(tmp_path).list_goals()[0].id
+    gid = Storage(tmp_path / "db.json").list_goals()[0].id
     result = runner.invoke(
         goal,
         ["update", gid, "--deadline", "2030-01-01"],
     )
     assert result.exit_code == 0
     assert (
-        Storage(tmp_path).get_goal(gid).deadline.strftime("%Y-%m-%d")
+        Storage(tmp_path / "db.json").get_goal(gid).deadline.strftime("%Y-%m-%d")
         == "2030-01-01"
     )

--- a/tests/test_migration_completed.py
+++ b/tests/test_migration_completed.py
@@ -10,6 +10,6 @@ def test_completed_migration(tmp_path: Path) -> None:
     db.table("goals").insert(
         {"id": "g1", "title": "t", "created": datetime.now().isoformat()}
     )
-    Storage(tmp_path)
+    Storage(tmp_path / "db.json")
     row = TinyDB(db_path).table("goals").get(Query().id == "g1")
     assert row["completed"] is False

--- a/tests/test_migration_tags.py
+++ b/tests/test_migration_tags.py
@@ -21,7 +21,7 @@ def test_tags_migration(tmp_path: Path) -> None:
         }
     )
 
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     goal1 = storage.get_goal("g1")
     goal2 = storage.get_goal("g2")
 
@@ -41,7 +41,7 @@ def test_tags_migration_updates_db(tmp_path: Path) -> None:
         }
     )
 
-    Storage(tmp_path)
+    Storage(tmp_path / "db.json")
 
     db2 = TinyDB(db_path)
     row = db2.table("goals").get(Query().id == "g1")

--- a/tests/test_pomo_quotes.py
+++ b/tests/test_pomo_quotes.py
@@ -14,7 +14,6 @@ from goal_glide.services import quotes
 def runner(monkeypatch, tmp_path: Path) -> CliRunner:
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
-    cfg._CONFIG_PATH = tmp_path / ".goal_glide" / "config.toml"
     return CliRunner()
 
 

--- a/tests/test_pomo_status.py
+++ b/tests/test_pomo_status.py
@@ -10,9 +10,6 @@ from goal_glide.services import pomodoro
 def test_status_no_session(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
-    monkeypatch.setenv("GOAL_GLIDE_SESSION_FILE", str(tmp_path / "session.json"))
-    import importlib
-    importlib.reload(pomodoro)
     runner = CliRunner()
     result = runner.invoke(cli.goal, ["pomo", "status"])
     assert result.exit_code == 0
@@ -22,9 +19,6 @@ def test_status_no_session(tmp_path: Path, monkeypatch):
 def test_status_with_session(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
-    monkeypatch.setenv("GOAL_GLIDE_SESSION_FILE", str(tmp_path / "session.json"))
-    import importlib
-    importlib.reload(pomodoro)
     start_time = datetime.datetime(2023, 1, 1, 12, 0, 0)
 
     class StartDT(datetime.datetime):
@@ -33,7 +27,9 @@ def test_status_with_session(tmp_path: Path, monkeypatch):
             return start_time
 
     monkeypatch.setattr(pomodoro, "datetime", StartDT)
-    pomodoro.start_session(30)
+    session_path = tmp_path / "session.json"
+    config_path = tmp_path / "config.toml"
+    pomodoro.start_session(30, None, session_path, config_path)
 
     later = start_time + datetime.timedelta(minutes=10)
 
@@ -53,9 +49,6 @@ def test_status_with_session(tmp_path: Path, monkeypatch):
 def test_status_paused(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
-    monkeypatch.setenv("GOAL_GLIDE_SESSION_FILE", str(tmp_path / "session.json"))
-    import importlib
-    importlib.reload(pomodoro)
     start_time = datetime.datetime(2023, 1, 1, 12, 0, 0)
 
     class StartDT(datetime.datetime):
@@ -64,12 +57,14 @@ def test_status_paused(tmp_path: Path, monkeypatch):
             return start_time
 
     monkeypatch.setattr(pomodoro, "datetime", StartDT)
-    pomodoro.start_session(30)
+    session_path = tmp_path / "session.json"
+    config_path = tmp_path / "config.toml"
+    pomodoro.start_session(30, None, session_path, config_path)
 
     later = start_time + datetime.timedelta(minutes=10)
     dt_cls = type("DT", (datetime.datetime,), {"now": classmethod(lambda cls: later)})
     monkeypatch.setattr(pomodoro, "datetime", dt_cls)
-    pomodoro.pause_session()
+    pomodoro.pause_session(session_path)
 
     much_later = start_time + datetime.timedelta(minutes=20)
 

--- a/tests/test_pomodoro_service.py
+++ b/tests/test_pomodoro_service.py
@@ -11,12 +11,13 @@ from goal_glide import config
 
 
 @pytest.fixture()
-def session_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
-    path = tmp_path / "session.json"
-    monkeypatch.setenv("GOAL_GLIDE_SESSION_FILE", str(path))
-    import importlib
-    importlib.reload(pomodoro)
-    return path
+def session_path(tmp_path: Path) -> Path:
+    return tmp_path / "session.json"
+
+
+@pytest.fixture()
+def config_path(tmp_path: Path) -> Path:
+    return tmp_path / "config.toml"
 
 
 def _patch_now(monkeypatch: pytest.MonkeyPatch, when: datetime) -> None:
@@ -29,11 +30,11 @@ def _patch_now(monkeypatch: pytest.MonkeyPatch, when: datetime) -> None:
 
 
 def test_start_session_writes_file(
-    monkeypatch: pytest.MonkeyPatch, session_path: Path
+    monkeypatch: pytest.MonkeyPatch, session_path: Path, config_path: Path
 ) -> None:
     fake_now = datetime(2023, 1, 1, 12, 0, 0)
     _patch_now(monkeypatch, fake_now)
-    session = pomodoro.start_session(1)
+    session = pomodoro.start_session(1, None, session_path, config_path)
     assert isinstance(session, pomodoro.PomodoroSession)
     assert session.start == fake_now
     assert session.duration_sec == 60
@@ -44,57 +45,57 @@ def test_start_session_writes_file(
 
 
 def test_load_session_returns_equivalent(
-    monkeypatch: pytest.MonkeyPatch, session_path: Path
+    monkeypatch: pytest.MonkeyPatch, session_path: Path, config_path: Path
 ) -> None:
     fake_now = datetime(2023, 1, 1, 13, 0, 0)
     _patch_now(monkeypatch, fake_now)
-    original = pomodoro.start_session(1)
-    loaded = pomodoro.load_session()
+    original = pomodoro.start_session(1, None, session_path, config_path)
+    loaded = pomodoro.load_session(session_path)
     assert loaded == original
 
 
 def test_stop_session_deletes_file(
-    monkeypatch: pytest.MonkeyPatch, session_path: Path
+    monkeypatch: pytest.MonkeyPatch, session_path: Path, config_path: Path
 ) -> None:
     fake_now = datetime(2023, 1, 1, 14, 0, 0)
     _patch_now(monkeypatch, fake_now)
-    original = pomodoro.start_session(1)
-    stopped = pomodoro.stop_session()
+    original = pomodoro.start_session(1, None, session_path, config_path)
+    stopped = pomodoro.stop_session(session_path, config_path)
     assert stopped == original
     assert not session_path.exists()
 
 
-def test_stop_session_no_file_raises(session_path: Path) -> None:
+def test_stop_session_no_file_raises(session_path: Path, config_path: Path) -> None:
     with pytest.raises(RuntimeError):
-        pomodoro.stop_session()
+        pomodoro.stop_session(session_path, config_path)
 
 
-def test_pause_resume_flow(monkeypatch: pytest.MonkeyPatch, session_path: Path) -> None:
+def test_pause_resume_flow(monkeypatch: pytest.MonkeyPatch, session_path: Path, config_path: Path) -> None:
     start = datetime(2023, 1, 2, 9, 0, 0)
     _patch_now(monkeypatch, start)
-    pomodoro.start_session(10)
+    pomodoro.start_session(10, None, session_path, config_path)
 
     five = start + timedelta(minutes=5)
     _patch_now(monkeypatch, five)
-    paused = pomodoro.pause_session()
+    paused = pomodoro.pause_session(session_path)
     assert paused.paused is True
     data = json.loads(session_path.read_text())
     assert data["elapsed_sec"] == 300
 
     seven = start + timedelta(minutes=7)
     _patch_now(monkeypatch, seven)
-    resumed = pomodoro.resume_session()
+    resumed = pomodoro.resume_session(session_path)
     assert resumed.paused is False
     assert json.loads(session_path.read_text())["elapsed_sec"] == 300
 
     twelve = start + timedelta(minutes=12)
     _patch_now(monkeypatch, twelve)
-    pomodoro.stop_session()
+    pomodoro.stop_session(session_path, config_path)
 
 
 def test_start_session_uses_config_default(
-    monkeypatch: pytest.MonkeyPatch, session_path: Path
+    monkeypatch: pytest.MonkeyPatch, session_path: Path, config_path: Path
 ) -> None:
-    monkeypatch.setattr(config, "pomo_duration", lambda: 3)
-    session = pomodoro.start_session()
+    monkeypatch.setattr(config, "pomo_duration", lambda p: 3)
+    session = pomodoro.start_session(None, None, session_path, config_path)
     assert session.duration_sec == 180

--- a/tests/test_reminder.py
+++ b/tests/test_reminder.py
@@ -15,36 +15,40 @@ from goal_glide.services import notify, reminder
 
 
 @pytest.fixture()
-def runner(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> CliRunner:
+def runner(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> tuple[CliRunner, Path]:
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
-    cfg._CONFIG_PATH = tmp_path / ".goal_glide" / "config.toml"
-    return CliRunner()
+    cfg_path = tmp_path / "config.toml"
+    return CliRunner(), cfg_path
 
 
-def test_enable_disable_updates_config(runner: CliRunner) -> None:
-    runner.invoke(cli.goal, ["reminder", "enable"])
-    assert cfg.reminders_enabled() is True
-    runner.invoke(cli.goal, ["reminder", "disable"])
-    assert cfg.reminders_enabled() is False
+def test_enable_disable_updates_config(runner: tuple[CliRunner, Path]) -> None:
+    cli_runner, cfg_path = runner
+    cli_runner.invoke(cli.goal, ["reminder", "enable"])
+    assert cfg.reminders_enabled(cfg_path) is True
+    cli_runner.invoke(cli.goal, ["reminder", "disable"])
+    assert cfg.reminders_enabled(cfg_path) is False
 
 
-def test_config_command_updates_values(runner: CliRunner) -> None:
-    runner.invoke(cli.goal, ["reminder", "config", "--break", "10", "--interval", "15"])
-    assert cfg.reminder_break() == 10
-    assert cfg.reminder_interval() == 15
+def test_config_command_updates_values(runner: tuple[CliRunner, Path]) -> None:
+    cli_runner, cfg_path = runner
+    cli_runner.invoke(cli.goal, ["reminder", "config", "--break", "10", "--interval", "15"])
+    assert cfg.reminder_break(cfg_path) == 10
+    assert cfg.reminder_interval(cfg_path) == 15
 
 
 @pytest.mark.parametrize("val", [0, -5, 200])
-def test_invalid_break_value_errors(val: int, runner: CliRunner) -> None:
-    result = runner.invoke(cli.goal, ["reminder", "config", "--break", str(val)])
+def test_invalid_break_value_errors(val: int, runner: tuple[CliRunner, Path]) -> None:
+    cli_runner, _ = runner
+    result = cli_runner.invoke(cli.goal, ["reminder", "config", "--break", str(val)])
     assert result.exit_code != 0
     assert "break must be between 1 and 120" in result.output
 
 
 @pytest.mark.parametrize("val", [0, -5, 200])
-def test_invalid_interval_value_errors(val: int, runner: CliRunner) -> None:
-    result = runner.invoke(cli.goal, ["reminder", "config", "--interval", str(val)])
+def test_invalid_interval_value_errors(val: int, runner: tuple[CliRunner, Path]) -> None:
+    cli_runner, _ = runner
+    result = cli_runner.invoke(cli.goal, ["reminder", "config", "--interval", str(val)])
     assert result.exit_code != 0
     assert "interval must be between 1 and 120" in result.output
 
@@ -72,7 +76,7 @@ def test_notification_backend_selection(monkeypatch: pytest.MonkeyPatch) -> None
 def test_schedule_after_stop_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(reminder, "_sched", None)
     monkeypatch.setattr(cfg, "reminders_enabled", lambda: False)
-    reminder.schedule_after_stop()
+    reminder.schedule_after_stop(Path("dummy"))
     assert reminder._sched is None
 
 
@@ -103,7 +107,7 @@ def test_schedule_after_stop_creates_scheduler(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setattr(reminder, "_sched", None)
     monkeypatch.setattr(reminder, "reminders_enabled", lambda: True)
 
-    reminder.schedule_after_stop()
+    reminder.schedule_after_stop(Path("dummy"))
 
     assert len(created) == 1
     assert started == [True]
@@ -112,17 +116,18 @@ def test_schedule_after_stop_creates_scheduler(monkeypatch: pytest.MonkeyPatch) 
     assert [job["id"] for job in sched.jobs] == ["break_end", "next_pomo"]
 
 
-def test_reminder_status_output(runner: CliRunner) -> None:
-    result = runner.invoke(cli.goal, ["reminder", "status"])
+def test_reminder_status_output(runner: tuple[CliRunner, Path]) -> None:
+    cli_runner, cfg_path = runner
+    result = cli_runner.invoke(cli.goal, ["reminder", "status"])
     assert result.exit_code == 0
     assert "Enabled: False | Break: 5m | Interval: 30m" in result.output
 
-    runner.invoke(cli.goal, ["reminder", "enable"])
-    runner.invoke(
+    cli_runner.invoke(cli.goal, ["reminder", "enable"])
+    cli_runner.invoke(
         cli.goal,
         ["reminder", "config", "--break", "11", "--interval", "22"],
     )
-    result = runner.invoke(cli.goal, ["reminder", "status"])
+    result = cli_runner.invoke(cli.goal, ["reminder", "status"])
     assert result.exit_code == 0
     assert "Enabled: True | Break: 11m | Interval: 22m" in result.output
 

--- a/tests/test_report_cli.py
+++ b/tests/test_report_cli.py
@@ -39,7 +39,7 @@ def test_cli_creates_html(
     tmp_path: Path, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(report, "date", FakeDate)
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     seed(storage)
     out = tmp_path / "rep.html"
     result = runner.invoke(
@@ -62,7 +62,7 @@ def test_cli_custom_range(
     tmp_path: Path, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(report, "date", FakeDate)
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     seed(storage)
     out = tmp_path / "range.html"
     result = runner.invoke(
@@ -145,7 +145,7 @@ def test_cli_default_output_path(
 ) -> None:
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setattr(report, "date", FakeDate)
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     seed(storage)
     result = runner.invoke(
         cli.goal,
@@ -162,7 +162,7 @@ def test_cli_md_and_csv(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(report, "date", FakeDate)
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     seed(storage)
     md_out = tmp_path / "rep.md"
     csv_out = tmp_path / "rep.csv"
@@ -191,7 +191,7 @@ def test_cli_empty_storage_reports(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(report, "date", FakeDate)
-    Storage(tmp_path)  # initialize empty storage
+    Storage(tmp_path / "db.json")  # initialize empty storage
     md_out = tmp_path / "empty.md"
     csv_out = tmp_path / "empty.csv"
     result_md = runner.invoke(

--- a/tests/test_report_service.py
+++ b/tests/test_report_service.py
@@ -137,7 +137,7 @@ def test_csv_output_rows_and_headers(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(report, "date", FakeDate)
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     seed(storage)
     out = report.build_report(storage, "week", "csv", tmp_path / "r.csv")
     df = pd.read_csv(out)
@@ -149,7 +149,7 @@ def test_html_contains_sections(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(report, "date", FakeDate)
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     seed(storage)
     out = report.build_report(storage, "week", "html", tmp_path / "r.html")
     text = out.read_text()
@@ -161,7 +161,7 @@ def test_html_contains_sections(
 
 def test_markdown_formatting(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(report, "date", FakeDate)
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     seed(storage)
     out = report.build_report(storage, "week", "md", tmp_path / "r.md")
     text = out.read_text()
@@ -171,7 +171,7 @@ def test_markdown_formatting(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
 
 def test_empty_storage_outputs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(report, "date", FakeDate)
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     html = report.build_report(storage, "week", "html", tmp_path / "e.html")
     csv = report.build_report(storage, "week", "csv", tmp_path / "e.csv")
     md = report.build_report(storage, "week", "md", tmp_path / "e.md")
@@ -192,7 +192,7 @@ def test_empty_html_contains_sections(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(report, "date", FakeDate)
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     out = report.build_report(storage, "week", "html", tmp_path / "empty.html")
     text = out.read_text()
     assert "Streak" in text
@@ -204,7 +204,7 @@ def test_custom_range_skips_date_window(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(report, "date", FakeDate)
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     seed(storage)
 
     def boom(*args: object, **kwargs: object) -> None:
@@ -225,7 +225,7 @@ def test_html_top_goals_limit_and_order(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(report, "date", FakeDate)
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     seed_many(storage)
     out = report.build_report(storage, "week", "html", tmp_path / "top.html")
     soup = BeautifulSoup(out.read_text(), "html.parser")
@@ -240,7 +240,7 @@ def test_tag_totals_with_overlapping_tags(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(report, "date", FakeDate)
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
 
     week_start = FakeDate.today() - timedelta(days=FakeDate.today().weekday())
 

--- a/tests/test_stats_cmd.py
+++ b/tests/test_stats_cmd.py
@@ -29,7 +29,7 @@ def make_session(day: date, dur: int = 3600, goal_id: str = "g") -> PomodoroSess
 def test_stats_week_output_has_7_bars(
     runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     start = date(2023, 6, 5)  # Monday
     for i in range(7):
         storage.add_session(make_session(start + timedelta(days=i)))
@@ -57,7 +57,7 @@ def test_stats_week_output_has_7_bars(
 def test_stats_month_output_has_4_bars(
     runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     start = date(2023, 4, 3)  # first Monday of April
     for i in range(28):
         storage.add_session(make_session(start + timedelta(days=i)))
@@ -83,7 +83,7 @@ def test_stats_month_output_has_4_bars(
 def test_stats_goals_table_shows_top5(
     runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     for i in range(6):
         storage.add_session(
             make_session(date(2023, 6, 1), dur=3600 * (i + 1), goal_id=f"g{i}")
@@ -123,7 +123,7 @@ def test_stats_empty_db_graceful(
 def test_stats_custom_range(
     runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     start_day = date(2023, 1, 1)
     for i in range(3):
         storage.add_session(make_session(start_day + timedelta(days=i)))

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -12,4 +12,4 @@ def test_corrupt_db_file_raises(tmp_path: Path) -> None:
     db_file = tmp_path / "db.json"
     db_file.write_text("{ bad json")
     with pytest.raises(JSONDecodeError):
-        Storage(tmp_path)
+        Storage(tmp_path / "db.json")

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -17,42 +17,42 @@ def runner(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> CliRunner:
 
 def test_add_single_tag(tmp_path: Path, runner: CliRunner) -> None:
     runner.invoke(goal, ["add", "g"])
-    gid = Storage(tmp_path).list_goals()[0].id
+    gid = Storage(tmp_path / "db.json").list_goals()[0].id
     result = runner.invoke(goal, ["tag", "add", gid, "writing"])
     assert result.exit_code == 0
     assert "writing" in result.output
-    assert Storage(tmp_path).get_goal(gid).tags == ["writing"]
+    assert Storage(tmp_path / "db.json").get_goal(gid).tags == ["writing"]
 
 
 def test_add_duplicate_tag_no_dupe(tmp_path: Path, runner: CliRunner) -> None:
     runner.invoke(goal, ["add", "g"])
-    gid = Storage(tmp_path).list_goals()[0].id
+    gid = Storage(tmp_path / "db.json").list_goals()[0].id
     runner.invoke(goal, ["tag", "add", gid, "health"])
     result = runner.invoke(goal, ["tag", "add", gid, "health"])
     assert result.exit_code == 0
-    assert Storage(tmp_path).get_goal(gid).tags == ["health"]
+    assert Storage(tmp_path / "db.json").get_goal(gid).tags == ["health"]
 
 
 def test_add_invalid_tag_fails(tmp_path: Path, runner: CliRunner) -> None:
     runner.invoke(goal, ["add", "g"])
-    gid = Storage(tmp_path).list_goals()[0].id
+    gid = Storage(tmp_path / "db.json").list_goals()[0].id
     result = runner.invoke(goal, ["tag", "add", gid, "BadTag!"])
     assert result.exit_code != 0
-    assert not Storage(tmp_path).get_goal(gid).tags
+    assert not Storage(tmp_path / "db.json").get_goal(gid).tags
 
 
 def test_remove_tag(tmp_path: Path, runner: CliRunner) -> None:
     runner.invoke(goal, ["add", "g"])
-    gid = Storage(tmp_path).list_goals()[0].id
+    gid = Storage(tmp_path / "db.json").list_goals()[0].id
     runner.invoke(goal, ["tag", "add", gid, "a", "b"])
     result = runner.invoke(goal, ["tag", "rm", gid, "a"])
     assert result.exit_code == 0
-    assert Storage(tmp_path).get_goal(gid).tags == ["b"]
+    assert Storage(tmp_path / "db.json").get_goal(gid).tags == ["b"]
 
 
 def test_remove_nonexistent_tag_warns(tmp_path: Path, runner: CliRunner) -> None:
     runner.invoke(goal, ["add", "g"])
-    gid = Storage(tmp_path).list_goals()[0].id
+    gid = Storage(tmp_path / "db.json").list_goals()[0].id
     result = runner.invoke(goal, ["tag", "rm", gid, "none"])
     assert result.exit_code == 0
     assert "not present" in result.output
@@ -61,7 +61,7 @@ def test_remove_nonexistent_tag_warns(tmp_path: Path, runner: CliRunner) -> None
 def test_list_filter_single_tag(tmp_path: Path, runner: CliRunner) -> None:
     runner.invoke(goal, ["add", "g1"])
     runner.invoke(goal, ["add", "g2"])
-    goals = Storage(tmp_path).list_goals()
+    goals = Storage(tmp_path / "db.json").list_goals()
     runner.invoke(goal, ["tag", "add", goals[0].id, "work"])
     runner.invoke(goal, ["tag", "add", goals[1].id, "play"])
     result = runner.invoke(goal, ["list", "--tag", "work"])
@@ -70,10 +70,10 @@ def test_list_filter_single_tag(tmp_path: Path, runner: CliRunner) -> None:
 
 def test_list_filter_multiple_tags_and_logic(tmp_path: Path, runner: CliRunner) -> None:
     runner.invoke(goal, ["add", "g1"])
-    gid = Storage(tmp_path).list_goals()[0].id
+    gid = Storage(tmp_path / "db.json").list_goals()[0].id
     runner.invoke(goal, ["tag", "add", gid, "a", "b"])
     runner.invoke(goal, ["add", "g2"])
-    gid2 = Storage(tmp_path).list_goals()[1].id
+    gid2 = Storage(tmp_path / "db.json").list_goals()[1].id
     runner.invoke(goal, ["tag", "add", gid2, "a"])
     result = runner.invoke(goal, ["list", "--tag", "a", "--tag", "b"])
     assert "g1" in result.output and "g2" not in result.output
@@ -82,7 +82,7 @@ def test_list_filter_multiple_tags_and_logic(tmp_path: Path, runner: CliRunner) 
 def test_tag_list_counts(tmp_path: Path, runner: CliRunner) -> None:
     runner.invoke(goal, ["add", "g1"])
     runner.invoke(goal, ["add", "g2"])
-    goals = Storage(tmp_path).list_goals()
+    goals = Storage(tmp_path / "db.json").list_goals()
     runner.invoke(goal, ["tag", "add", goals[0].id, "work", "fun"])
     runner.invoke(goal, ["tag", "add", goals[1].id, "work"])
     result = runner.invoke(goal, ["tag", "list"])

--- a/tests/test_thoughts.py
+++ b/tests/test_thoughts.py
@@ -20,7 +20,7 @@ def runner(monkeypatch, tmp_path: Path) -> CliRunner:
 def test_jot_basic(tmp_path: Path, runner: CliRunner) -> None:
     result = runner.invoke(thought, ["jot", "note"])
     assert result.exit_code == 0
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     thoughts = storage.list_thoughts()
     assert len(thoughts) == 1
     assert thoughts[0].text == "note"
@@ -29,21 +29,21 @@ def test_jot_basic(tmp_path: Path, runner: CliRunner) -> None:
 
 def test_jot_with_goal(tmp_path: Path, runner: CliRunner) -> None:
     runner.invoke(goal, ["add", "goal 1"])
-    goal_id = Storage(tmp_path).list_goals()[0].id
+    goal_id = Storage(tmp_path / "db.json").list_goals()[0].id
     result = runner.invoke(thought, ["jot", "idea", "-g", goal_id])
     assert result.exit_code == 0
-    t = Storage(tmp_path).list_thoughts()[0]
+    t = Storage(tmp_path / "db.json").list_thoughts()[0]
     assert t.goal_id == goal_id
 
 
 def test_jot_blank_fails(tmp_path: Path, runner: CliRunner) -> None:
     result = runner.invoke(thought, ["jot", "  "])
     assert result.exit_code != 0
-    assert not Storage(tmp_path).list_thoughts()
+    assert not Storage(tmp_path / "db.json").list_thoughts()
 
 
 def test_list_default_order(tmp_path: Path, runner: CliRunner) -> None:
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     older = Thought(id="1", text="old", timestamp=datetime.now() - timedelta(hours=1))
     newer = Thought(id="2", text="new", timestamp=datetime.now())
     storage.add_thought(older)
@@ -55,7 +55,7 @@ def test_list_default_order(tmp_path: Path, runner: CliRunner) -> None:
 
 
 def test_list_limit(tmp_path: Path, runner: CliRunner) -> None:
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     for i in range(5):
         storage.add_thought(Thought(id=str(i), text=f"t{i}", timestamp=datetime.now()))
     result = runner.invoke(thought, ["list", "--limit", "3"])
@@ -66,9 +66,9 @@ def test_list_limit(tmp_path: Path, runner: CliRunner) -> None:
 
 def test_list_goal_filter(tmp_path: Path, runner: CliRunner) -> None:
     runner.invoke(goal, ["add", "g"])
-    goal_id = Storage(tmp_path).list_goals()[0].id
-    Storage(tmp_path).add_thought(Thought(id="1", text="a", timestamp=datetime.now()))
-    Storage(tmp_path).add_thought(
+    goal_id = Storage(tmp_path / "db.json").list_goals()[0].id
+    Storage(tmp_path / "db.json").add_thought(Thought(id="1", text="a", timestamp=datetime.now()))
+    Storage(tmp_path / "db.json").add_thought(
         Thought(id="2", text="b", timestamp=datetime.now(), goal_id=goal_id)
     )
     result = runner.invoke(thought, ["list", "-g", goal_id])
@@ -79,21 +79,21 @@ def test_list_goal_filter(tmp_path: Path, runner: CliRunner) -> None:
 
 def test_migration_keeps_other_tables(tmp_path: Path, runner: CliRunner) -> None:
     # seed pre-existing tables
-    db = Storage(tmp_path).db
+    db = Storage(tmp_path / "db.json").db
     db.table("goals").insert({"id": "g"})
     db.table("sessions").insert({"id": "s"})
-    Storage(tmp_path).add_thought(Thought(id="t", text="x", timestamp=datetime.now()))
-    db2 = Storage(tmp_path).db
+    Storage(tmp_path / "db.json").add_thought(Thought(id="t", text="x", timestamp=datetime.now()))
+    db2 = Storage(tmp_path / "db.json").db
     assert len(db2.table("goals").all()) == 1
     assert len(db2.table("sessions").all()) == 1
 
 
 def test_remove_thought(tmp_path: Path, runner: CliRunner) -> None:
     t = Thought(id="x", text="bye", timestamp=datetime.now())
-    Storage(tmp_path).add_thought(t)
+    Storage(tmp_path / "db.json").add_thought(t)
     result = runner.invoke(thought, ["rm", "x"])
     assert result.exit_code == 0
-    assert not Storage(tmp_path).list_thoughts()
+    assert not Storage(tmp_path / "db.json").list_thoughts()
 
 
 def test_remove_thought_missing(tmp_path: Path, runner: CliRunner) -> None:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -16,9 +16,6 @@ def _setup_textual() -> bool:
 def app_env(monkeypatch, tmp_path):
     monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
     monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("GOAL_GLIDE_SESSION_FILE", str(tmp_path / "session.json"))
-    import importlib
-    importlib.reload(pomodoro)
     yield
 
 
@@ -40,7 +37,7 @@ def test_toggle_pomo(app_env, tmp_path):
         pytest.skip("textual not available")
     from goal_glide.tui import GoalGlideApp
 
-    storage = Storage(tmp_path)
+    storage = Storage(tmp_path / "db.json")
     g = Goal(id="g1", title="g", created=datetime.utcnow())
     storage.add_goal(g)
 
@@ -70,12 +67,12 @@ def test_add_and_archive_goal(app_env, tmp_path):
             await pilot.press("enter")
             await pilot.press("enter")
             tree = pilot.app.query_one(Tree)
-            goals = Storage(tmp_path).list_goals()
+            goals = Storage(tmp_path / "db.json").list_goals()
             assert len(tree.root.children) == 1
             gid = goals[0].id
             pilot.app.selected_goal = gid
             await pilot.press("delete")
             assert len(tree.root.children) == 0
-            assert Storage(tmp_path).get_goal(gid).archived is True
+            assert Storage(tmp_path / "db.json").get_goal(gid).archived is True
 
     asyncio.run(run())


### PR DESCRIPTION
## Summary
- centralize default path logic in CLI context
- inject DB/config/session paths into storage and services
- adapt configuration and pomodoro modules to accept paths
- update reminder scheduling to take explicit config path
- refactor tests for new dependency model

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_68466f595840832281fe8b4f51cff1a7