### PR TITLE
Fix import order for ruff

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,11 +1,12 @@
 # Configuration file for the Sphinx documentation builder.
 
-project = 'Goal Glide'
-author = 'Goal Glide Developers'
-
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath('..'))
+
+project = 'Goal Glide'
+author = 'Goal Glide Developers'
 
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon']
 autodoc_mock_imports = [

--- a/tests/test_goal_subgoals.py
+++ b/tests/test_goal_subgoals.py
@@ -81,8 +81,6 @@ def test_list_goals_parent_missing_returns_empty(tmp_path: Path) -> None:
     assert storage.list_goals(parent_id="missing") == []
 
 
-
-
 @st.composite
 def _parent_child_mapping(draw: st.DrawFn) -> dict[str, list[str]]:
     parents = draw(

--- a/tests/test_goal_subgoals.py
+++ b/tests/test_goal_subgoals.py
@@ -7,6 +7,7 @@ from click.testing import CliRunner
 from goal_glide.cli import goal
 from goal_glide.models.goal import Goal
 from goal_glide.models.storage import Storage
+from hypothesis import given, settings, strategies as st
 
 
 def test_store_and_retrieve_parent(tmp_path: Path) -> None:
@@ -80,7 +81,6 @@ def test_list_goals_parent_missing_returns_empty(tmp_path: Path) -> None:
     assert storage.list_goals(parent_id="missing") == []
 
 
-from hypothesis import given, settings, strategies as st
 
 
 @st.composite


### PR DESCRIPTION
## Summary
- make `docs/conf.py` import modules before variable assignments
- move Hypothesis imports to top of `tests/test_goal_subgoals.py`

## Testing
- `ruff check docs/conf.py tests/test_goal_subgoals.py`

------
https://chatgpt.com/codex/tasks/task_e_68467b8f277483228d7490c41bf759be