### PR TITLE
Add rust requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Features include:
 
 ## Installation
 
-1. Install Python 3.11 or newer.
+1. Install Python 3.11 or newer. The Rust compiler is also required to build
+   some dependencies (install via [rustup](https://rustup.rs/), especially on
+   Apple M-series Macs).
 2. Clone this repository and create a virtual environment:
 
 ```bash


### PR DESCRIPTION
## Summary
- mention that the Rust compiler is needed, especially for Apple M-series systems

## Testing
- `poetry run pytest -q` *(fails: DeadlineExceeded in test_property_total_time)*

------
https://chatgpt.com/codex/tasks/task_e_68467fd00e54832296e56387ef919824