### PR TITLE
Add shared CliRunner fixture for CLI tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 from click.testing import CliRunner
 
+
 @pytest.fixture()
 def runner(tmp_path, monkeypatch):
     monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+from click.testing import CliRunner
+
+@pytest.fixture()
+def runner(tmp_path, monkeypatch):
+    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("GOAL_GLIDE_SESSION_FILE", str(tmp_path / "session.json"))
+    return CliRunner()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,17 +10,14 @@ from goal_glide.models.storage import Storage
 from goal_glide.services import pomodoro
 
 
-def test_add_list_remove(tmp_path):
-    runner = CliRunner()
+def test_add_list_remove(tmp_path, runner: CliRunner):
 
     # add goal
-    result = runner.invoke(
-        cli.goal, ["add", "Test Goal"], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)}
-    )
+    result = runner.invoke(cli.goal, ["add", "Test Goal"])
     assert result.exit_code == 0
 
     # list
-    result = runner.invoke(cli.goal, ["list"], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)})
+    result = runner.invoke(cli.goal, ["list"])
     assert "Test" in result.output
 
     # remove using id from storage (rich table may truncate id)
@@ -29,52 +26,33 @@ def test_add_list_remove(tmp_path):
         cli.goal,
         ["remove", goal_id],
         input="y\n",
-        env={"GOAL_GLIDE_DB_DIR": str(tmp_path)},
     )
     assert result.exit_code == 0
 
 
-def test_add_duplicate_goal_warning(tmp_path) -> None:
+def test_add_duplicate_goal_warning(tmp_path, runner: CliRunner) -> None:
     """Adding a goal twice should show a warning message."""
-    env = {"GOAL_GLIDE_DB_DIR": str(tmp_path)}
-    runner = CliRunner()
-
-    runner.invoke(cli.goal, ["add", "dup"], env=env)
-    result = runner.invoke(cli.goal, ["add", "dup"], env=env)
+    runner.invoke(cli.goal, ["add", "dup"])
+    result = runner.invoke(cli.goal, ["add", "dup"])
 
     assert result.exit_code == 0
     assert "Warning: goal with this title already exists." in result.output
 
 
-def test_pomo_session_persisted(tmp_path, monkeypatch):
-    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("GOAL_GLIDE_SESSION_FILE", str(tmp_path / "session.json"))
+def test_pomo_session_persisted(tmp_path, monkeypatch, runner: CliRunner):
     import importlib
     importlib.reload(pomodoro)
-    runner = CliRunner()
-    res = runner.invoke(
-        cli.goal, ["add", "G"], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)}
-    )
+    res = runner.invoke(cli.goal, ["add", "G"])
     gid = res.output.split()[-1].strip("()")
     runner.invoke(
         cli.goal,
         ["pomo", "start", "--duration", "1", "--goal", gid],
-        env={"GOAL_GLIDE_DB_DIR": str(tmp_path)},
     )
-    runner.invoke(cli.goal, ["pomo", "stop"], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)})
+    runner.invoke(cli.goal, ["pomo", "stop"])
     # ensure further pomodoro commands see no active session
-    status = runner.invoke(
-        cli.goal,
-        ["pomo", "status"],
-        env={"GOAL_GLIDE_DB_DIR": str(tmp_path)},
-    )
+    status = runner.invoke(cli.goal, ["pomo", "status"])
     assert "No active session" in status.output
-    paused = runner.invoke(
-        cli.goal,
-        ["pomo", "pause"],
-        env={"GOAL_GLIDE_DB_DIR": str(tmp_path)},
-    )
+    paused = runner.invoke(cli.goal, ["pomo", "pause"])
     assert paused.exit_code == 1
     storage = Storage(tmp_path)
     sessions = storage.list_sessions()
@@ -82,13 +60,9 @@ def test_pomo_session_persisted(tmp_path, monkeypatch):
     assert sessions[0].goal_id == gid
 
 
-def test_pomo_pause_resume(tmp_path, monkeypatch):
-    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("GOAL_GLIDE_SESSION_FILE", str(tmp_path / "session.json"))
+def test_pomo_pause_resume(tmp_path, monkeypatch, runner: CliRunner):
     import importlib
     importlib.reload(pomodoro)
-    runner = CliRunner()
     runner.invoke(cli.goal, ["pomo", "start", "--duration", "1"])
     res = runner.invoke(cli.goal, ["pomo", "pause"])
     assert res.exit_code == 0
@@ -98,10 +72,8 @@ def test_pomo_pause_resume(tmp_path, monkeypatch):
     assert "resumed" in res.output.lower()
 
 
-def test_jot_from_editor(tmp_path, monkeypatch):
-    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
+def test_jot_from_editor(tmp_path, monkeypatch, runner: CliRunner):
     monkeypatch.setattr(click, "edit", lambda *a, **k: "note from editor\n")
-    runner = CliRunner()
     result = runner.invoke(cli.thought, ["jot"])
     assert result.exit_code == 0
     thought_text = Storage(tmp_path).list_thoughts()[0].text
@@ -110,50 +82,42 @@ def test_jot_from_editor(tmp_path, monkeypatch):
 
 @pytest.mark.parametrize("cmd", ["remove", "archive", "update"])
 @pytest.mark.parametrize("goal_id", ["", "!!!", "x" * 100])
-def test_goal_commands_invalid_id(cmd, goal_id, tmp_path):
-    env = {"GOAL_GLIDE_DB_DIR": str(tmp_path)}
-    runner = CliRunner()
+def test_goal_commands_invalid_id(cmd, goal_id, tmp_path, runner: CliRunner):
     args = [cmd, goal_id]
     if cmd == "remove":
-        result = runner.invoke(cli.goal, args, input="y\n", env=env)
+        result = runner.invoke(cli.goal, args, input="y\n")
     else:
-        result = runner.invoke(cli.goal, args, env=env)
+        result = runner.invoke(cli.goal, args)
     assert result.exit_code == 1
     assert "Error:" in result.output
 
 
-def test_jot_from_editor_unicode(tmp_path, monkeypatch):
-    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
+def test_jot_from_editor_unicode(tmp_path, monkeypatch, runner: CliRunner):
     monkeypatch.setattr(click, "edit", lambda *a, **k: "Привет мир\n")
-    runner = CliRunner()
     result = runner.invoke(cli.thought, ["jot"])
     assert result.exit_code == 0
     stored = Storage(tmp_path).list_thoughts()[0].text
     assert stored == "Привет мир"
 
 
-def test_jot_from_editor_empty(tmp_path, monkeypatch):
-    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
+def test_jot_from_editor_empty(tmp_path, monkeypatch, runner: CliRunner):
     monkeypatch.setattr(click, "edit", lambda *a, **k: "")
-    runner = CliRunner()
     result = runner.invoke(cli.thought, ["jot"])
     assert result.exit_code == 1
     assert "Error:" in result.output
     assert Storage(tmp_path).list_thoughts() == []
 
 
-def test_config_quotes_disable(tmp_path, monkeypatch):
+def test_config_quotes_disable(tmp_path, monkeypatch, runner: CliRunner):
     monkeypatch.setattr(config, "_CONFIG_PATH", tmp_path / "config.toml")
-    runner = CliRunner()
     result = runner.invoke(cli.goal, ["config", "quotes", "--disable"])
     assert result.exit_code == 0
     assert "Quotes are OFF" in result.output
     assert config.quotes_enabled() is False
 
 
-def test_config_quotes_enable(tmp_path, monkeypatch):
+def test_config_quotes_enable(tmp_path, monkeypatch, runner: CliRunner):
     monkeypatch.setattr(config, "_CONFIG_PATH", tmp_path / "config.toml")
-    runner = CliRunner()
     runner.invoke(cli.goal, ["config", "quotes", "--disable"])
     result = runner.invoke(cli.goal, ["config", "quotes", "--enable"])
     assert result.exit_code == 0
@@ -161,63 +125,50 @@ def test_config_quotes_enable(tmp_path, monkeypatch):
     assert config.quotes_enabled() is True
 
 
-def test_pomo_start_after_archive(tmp_path, monkeypatch):
-    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("GOAL_GLIDE_SESSION_FILE", str(tmp_path / "session.json"))
+def test_pomo_start_after_archive(tmp_path, monkeypatch, runner: CliRunner):
     import importlib
     importlib.reload(pomodoro)
-    runner = CliRunner()
     add_res = runner.invoke(
         cli.goal,
         ["add", "g"],
-        env={"GOAL_GLIDE_DB_DIR": str(tmp_path)},
     )
     gid = add_res.output.split()[-1].strip("()")
-    runner.invoke(cli.goal, ["archive", gid], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)})
+    runner.invoke(cli.goal, ["archive", gid])
     start = runner.invoke(
         cli.goal,
         ["pomo", "start", "--duration", "1", "--goal", gid],
-        env={"GOAL_GLIDE_DB_DIR": str(tmp_path)},
     )
     assert start.exit_code == 0
     assert "Started pomodoro" in start.output
 
 
-def test_pomo_start_default_from_config(tmp_path, monkeypatch):
-    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("GOAL_GLIDE_SESSION_FILE", str(tmp_path / "session.json"))
+def test_pomo_start_default_from_config(tmp_path, monkeypatch, runner: CliRunner):
     import importlib
     importlib.reload(pomodoro)
     monkeypatch.setattr(config, "pomo_duration", lambda: 2)
-    runner = CliRunner()
     result = runner.invoke(
         cli.goal,
         ["pomo", "start"],
-        env={"GOAL_GLIDE_DB_DIR": str(tmp_path)},
     )
     assert result.exit_code == 0
     data = json.loads((tmp_path / "session.json").read_text())
     assert data["duration_sec"] == 120
 
 
-def test_list_due_filters(tmp_path):
-    env = {"GOAL_GLIDE_DB_DIR": str(tmp_path)}
-    runner = CliRunner()
+def test_list_due_filters(tmp_path, runner: CliRunner):
     soon = (datetime.utcnow() + timedelta(days=2)).strftime("%Y-%m-%d")
     later = (datetime.utcnow() + timedelta(days=5)).strftime("%Y-%m-%d")
     past = (datetime.utcnow() - timedelta(days=1)).strftime("%Y-%m-%d")
-    runner.invoke(cli.goal, ["add", "soon", "--deadline", soon], env=env)
-    runner.invoke(cli.goal, ["add", "later", "--deadline", later], env=env)
-    runner.invoke(cli.goal, ["add", "past", "--deadline", past], env=env)
+    runner.invoke(cli.goal, ["add", "soon", "--deadline", soon])
+    runner.invoke(cli.goal, ["add", "later", "--deadline", later])
+    runner.invoke(cli.goal, ["add", "past", "--deadline", past])
 
-    res = runner.invoke(cli.goal, ["list", "--due-soon"], env=env)
+    res = runner.invoke(cli.goal, ["list", "--due-soon"])
     assert "soon" in res.output
     assert "later" not in res.output
     assert "past" not in res.output
 
-    res = runner.invoke(cli.goal, ["list", "--overdue"], env=env)
+    res = runner.invoke(cli.goal, ["list", "--overdue"])
     assert "past" in res.output
     assert "soon" not in res.output
     assert "later" not in res.output

--- a/tests/test_goal_archive.py
+++ b/tests/test_goal_archive.py
@@ -7,18 +7,11 @@ sys.path.insert(0, str(_Path(__file__).resolve().parents[1]))
 
 from pathlib import Path
 
-import pytest
 from click.testing import CliRunner
 
 from goal_glide.cli import goal
 from goal_glide.models.goal import Priority
 from goal_glide.models.storage import Storage
-
-
-@pytest.fixture()
-def runner(monkeypatch, tmp_path: Path) -> CliRunner:
-    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
-    return CliRunner()
 
 
 def test_add_with_priority(tmp_path: Path, runner: CliRunner) -> None:
@@ -134,8 +127,8 @@ def test_list_archived_priority_filter(tmp_path: Path, runner: CliRunner) -> Non
 
 
 def test_list_shows_completed(tmp_path: Path, runner: CliRunner) -> None:
-    runner.invoke(goal, ["add", "g"], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)})
+    runner.invoke(goal, ["add", "g"])
     gid = Storage(tmp_path).list_goals()[0].id
-    runner.invoke(goal, ["complete", gid], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)})
-    result = runner.invoke(goal, ["list"], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)})
+    runner.invoke(goal, ["complete", gid])
+    result = runner.invoke(goal, ["list"])
     assert "Comple" in result.output

--- a/tests/test_goal_complete.py
+++ b/tests/test_goal_complete.py
@@ -1,26 +1,15 @@
-import pytest
 from click.testing import CliRunner
 from pathlib import Path
 from goal_glide.cli import goal
 from goal_glide.models.storage import Storage
 
 
-@pytest.fixture()
-def runner(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> CliRunner:
-    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
-    return CliRunner()
-
-
 def test_complete_and_reopen(tmp_path: Path, runner: CliRunner) -> None:
-    runner.invoke(goal, ["add", "g"], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)})
+    runner.invoke(goal, ["add", "g"])
     gid = Storage(tmp_path).list_goals()[0].id
-    result = runner.invoke(
-        goal, ["complete", gid], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)}
-    )
+    result = runner.invoke(goal, ["complete", gid])
     assert result.exit_code == 0
     assert Storage(tmp_path).get_goal(gid).completed is True
-    result = runner.invoke(
-        goal, ["reopen", gid], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)}
-    )
+    result = runner.invoke(goal, ["reopen", gid])
     assert result.exit_code == 0
     assert Storage(tmp_path).get_goal(gid).completed is False

--- a/tests/test_goal_update.py
+++ b/tests/test_goal_update.py
@@ -1,17 +1,10 @@
 from pathlib import Path
 
-import pytest
 from click.testing import CliRunner
 
 from goal_glide.cli import goal
 from goal_glide.models.goal import Priority
 from goal_glide.models.storage import Storage
-
-
-@pytest.fixture()
-def runner(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> CliRunner:
-    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
-    return CliRunner()
 
 
 def test_update_title(tmp_path: Path, runner: CliRunner) -> None:

--- a/tests/test_pomo_quotes.py
+++ b/tests/test_pomo_quotes.py
@@ -10,17 +10,12 @@ from goal_glide import config as cfg
 from goal_glide.services import quotes
 
 
-@pytest.fixture()
-def runner(monkeypatch, tmp_path: Path) -> CliRunner:
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
-    cfg._CONFIG_PATH = tmp_path / ".goal_glide" / "config.toml"
-    return CliRunner()
 
 
 def test_pomo_stop_prints_quote(
-    monkeypatch: pytest.MonkeyPatch, runner: CliRunner
+    monkeypatch: pytest.MonkeyPatch, runner: CliRunner, tmp_path: Path
 ) -> None:
+    monkeypatch.setattr(cfg, "_CONFIG_PATH", tmp_path / ".goal_glide" / "config.toml")
     monkeypatch.setattr(quotes, "get_random_quote", lambda use_online=True: ("Q", "A"))
     monkeypatch.setattr(cli, "get_random_quote", lambda use_online=True: ("Q", "A"))
     runner.invoke(cli.goal, ["pomo", "start", "--duration", "1"])
@@ -32,6 +27,7 @@ def test_pomo_stop_prints_quote(
 def test_quotes_disabled(
     monkeypatch: pytest.MonkeyPatch, runner: CliRunner, tmp_path: Path
 ) -> None:
+    monkeypatch.setattr(cfg, "_CONFIG_PATH", tmp_path / ".goal_glide" / "config.toml")
     path = tmp_path / ".goal_glide" / "config.toml"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("quotes_enabled = false", encoding="utf-8")
@@ -43,7 +39,10 @@ def test_quotes_disabled(
     assert "Q" not in result.output
 
 
-def test_quote_fallback(monkeypatch: pytest.MonkeyPatch, runner: CliRunner) -> None:
+def test_quote_fallback(
+    monkeypatch: pytest.MonkeyPatch, runner: CliRunner, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(cfg, "_CONFIG_PATH", tmp_path / ".goal_glide" / "config.toml")
     monkeypatch.setattr(
         quotes.requests,
         "get",
@@ -58,8 +57,9 @@ def test_quote_fallback(monkeypatch: pytest.MonkeyPatch, runner: CliRunner) -> N
 
 
 def test_quote_exception_handling(
-    monkeypatch: pytest.MonkeyPatch, runner: CliRunner
+    monkeypatch: pytest.MonkeyPatch, runner: CliRunner, tmp_path: Path
 ) -> None:
+    monkeypatch.setattr(cfg, "_CONFIG_PATH", tmp_path / ".goal_glide" / "config.toml")
     def boom(use_online: bool = True) -> tuple[str, str]:
         raise RuntimeError("boom")
 
@@ -72,8 +72,9 @@ def test_quote_exception_handling(
 
 
 def test_quotes_default_enabled(
-    monkeypatch: pytest.MonkeyPatch, runner: CliRunner
+    monkeypatch: pytest.MonkeyPatch, runner: CliRunner, tmp_path: Path
 ) -> None:
+    monkeypatch.setattr(cfg, "_CONFIG_PATH", tmp_path / ".goal_glide" / "config.toml")
     result = runner.invoke(cli.goal, ["config", "quotes"])
     assert result.exit_code == 0
     assert "Quotes are ON" in result.output
@@ -82,6 +83,7 @@ def test_quotes_default_enabled(
 def test_quotes_disabled_no_call(
     monkeypatch: pytest.MonkeyPatch, runner: CliRunner, tmp_path: Path
 ) -> None:
+    monkeypatch.setattr(cfg, "_CONFIG_PATH", tmp_path / ".goal_glide" / "config.toml")
     path = tmp_path / ".goal_glide" / "config.toml"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("quotes_enabled = false", encoding="utf-8")

--- a/tests/test_pomo_quotes.py
+++ b/tests/test_pomo_quotes.py
@@ -10,8 +10,6 @@ from goal_glide import config as cfg
 from goal_glide.services import quotes
 
 
-
-
 def test_pomo_stop_prints_quote(
     monkeypatch: pytest.MonkeyPatch, runner: CliRunner, tmp_path: Path
 ) -> None:
@@ -60,6 +58,7 @@ def test_quote_exception_handling(
     monkeypatch: pytest.MonkeyPatch, runner: CliRunner, tmp_path: Path
 ) -> None:
     monkeypatch.setattr(cfg, "_CONFIG_PATH", tmp_path / ".goal_glide" / "config.toml")
+
     def boom(use_online: bool = True) -> tuple[str, str]:
         raise RuntimeError("boom")
 

--- a/tests/test_pomo_status.py
+++ b/tests/test_pomo_status.py
@@ -7,21 +7,18 @@ from goal_glide import cli
 from goal_glide.services import pomodoro
 
 
-def test_status_no_session(tmp_path: Path, monkeypatch):
+def test_status_no_session(tmp_path: Path, monkeypatch, runner: CliRunner):
     monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
     monkeypatch.setenv("GOAL_GLIDE_SESSION_FILE", str(tmp_path / "session.json"))
     import importlib
     importlib.reload(pomodoro)
-    runner = CliRunner()
     result = runner.invoke(cli.goal, ["pomo", "status"])
     assert result.exit_code == 0
     assert "No active session" in result.output
 
 
-def test_status_with_session(tmp_path: Path, monkeypatch):
+def test_status_with_session(tmp_path: Path, monkeypatch, runner: CliRunner):
     monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
     monkeypatch.setenv("GOAL_GLIDE_SESSION_FILE", str(tmp_path / "session.json"))
     import importlib
     importlib.reload(pomodoro)
@@ -43,16 +40,14 @@ def test_status_with_session(tmp_path: Path, monkeypatch):
             return later
 
     monkeypatch.setattr(cli, "datetime", LaterDT)
-    runner = CliRunner()
     result = runner.invoke(cli.goal, ["pomo", "status"])
     assert result.exit_code == 0
     assert "Elapsed 10m" in result.output
     assert "Remaining 20m" in result.output
 
 
-def test_status_paused(tmp_path: Path, monkeypatch):
+def test_status_paused(tmp_path: Path, monkeypatch, runner: CliRunner):
     monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
     monkeypatch.setenv("GOAL_GLIDE_SESSION_FILE", str(tmp_path / "session.json"))
     import importlib
     importlib.reload(pomodoro)
@@ -79,7 +74,6 @@ def test_status_paused(tmp_path: Path, monkeypatch):
             return much_later
 
     monkeypatch.setattr(cli, "datetime", LaterDT)
-    runner = CliRunner()
     result = runner.invoke(cli.goal, ["pomo", "status"])
     assert result.exit_code == 0
     assert "Elapsed 10m" in result.output

--- a/tests/test_reminder.py
+++ b/tests/test_reminder.py
@@ -14,12 +14,11 @@ from goal_glide import config as cfg
 from goal_glide.services import notify, reminder
 
 
-@pytest.fixture()
-def runner(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> CliRunner:
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
+@pytest.fixture(autouse=True)
+def _cfg_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     cfg._CONFIG_PATH = tmp_path / ".goal_glide" / "config.toml"
-    return CliRunner()
+
+
 
 
 def test_enable_disable_updates_config(runner: CliRunner) -> None:

--- a/tests/test_reminder.py
+++ b/tests/test_reminder.py
@@ -19,8 +19,6 @@ def _cfg_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     cfg._CONFIG_PATH = tmp_path / ".goal_glide" / "config.toml"
 
 
-
-
 def test_enable_disable_updates_config(runner: CliRunner) -> None:
     runner.invoke(cli.goal, ["reminder", "enable"])
     assert cfg.reminders_enabled() is True

--- a/tests/test_report_cli.py
+++ b/tests/test_report_cli.py
@@ -15,8 +15,6 @@ from goal_glide.models.storage import Storage
 from goal_glide.services import report
 
 
-
-
 class FakeDate(date):
     @classmethod
     def today(cls) -> date:  # type: ignore[override]

--- a/tests/test_report_cli.py
+++ b/tests/test_report_cli.py
@@ -15,10 +15,6 @@ from goal_glide.models.storage import Storage
 from goal_glide.services import report
 
 
-@pytest.fixture()
-def runner(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> CliRunner:
-    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
-    return CliRunner()
 
 
 class FakeDate(date):
@@ -45,7 +41,6 @@ def test_cli_creates_html(
     result = runner.invoke(
         cli.goal,
         ["report", "make", "--out", str(out)],
-        env={"GOAL_GLIDE_DB_DIR": str(tmp_path)},
     )
     assert result.exit_code == 0
     assert out.exists()
@@ -77,7 +72,6 @@ def test_cli_custom_range(
             "--out",
             str(out),
         ],
-        env={"GOAL_GLIDE_DB_DIR": str(tmp_path)},
     )
     assert result.exit_code == 0
     assert out.exists()
@@ -117,7 +111,6 @@ def test_cli_range_flags(
     result = runner.invoke(
         cli.goal,
         ["report", "make", flag],
-        env={"GOAL_GLIDE_DB_DIR": str(tmp_path)},
     )
     assert result.exit_code == 0
     assert captured == [expected]
@@ -150,7 +143,6 @@ def test_cli_default_output_path(
     result = runner.invoke(
         cli.goal,
         ["report", "make", "--week"],
-        env={"GOAL_GLIDE_DB_DIR": str(tmp_path)},
     )
     assert result.exit_code == 0
     assert list(tmp_path.glob("GoalGlide_week_*"))
@@ -169,12 +161,10 @@ def test_cli_md_and_csv(
     result_md = runner.invoke(
         cli.goal,
         ["report", "make", "--format", "md", "--out", str(md_out)],
-        env={"GOAL_GLIDE_DB_DIR": str(tmp_path)},
     )
     result_csv = runner.invoke(
         cli.goal,
         ["report", "make", "--format", "csv", "--out", str(csv_out)],
-        env={"GOAL_GLIDE_DB_DIR": str(tmp_path)},
     )
     assert result_md.exit_code == 0
     assert result_csv.exit_code == 0
@@ -197,12 +187,10 @@ def test_cli_empty_storage_reports(
     result_md = runner.invoke(
         cli.goal,
         ["report", "make", "--format", "md", "--out", str(md_out)],
-        env={"GOAL_GLIDE_DB_DIR": str(tmp_path)},
     )
     result_csv = runner.invoke(
         cli.goal,
         ["report", "make", "--format", "csv", "--out", str(csv_out)],
-        env={"GOAL_GLIDE_DB_DIR": str(tmp_path)},
     )
     assert result_md.exit_code == 0
     assert result_csv.exit_code == 0

--- a/tests/test_stats_cmd.py
+++ b/tests/test_stats_cmd.py
@@ -11,12 +11,6 @@ from goal_glide.models.session import PomodoroSession
 from goal_glide.models.storage import Storage
 
 
-@pytest.fixture()
-def runner(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> CliRunner:
-    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
-    return CliRunner()
-
-
 def make_session(day: date, dur: int = 3600, goal_id: str = "g") -> PomodoroSession:
     return PomodoroSession(
         id=f"{goal_id}-{day}",
@@ -40,9 +34,7 @@ def test_stats_week_output_has_7_bars(
             return datetime(2023, 6, 11)
 
     monkeypatch.setattr(cli, "datetime", FakeDT)
-    result = runner.invoke(
-        cli.goal, ["stats"], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)}
-    )
+    result = runner.invoke(cli.goal, ["stats"])
     days = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
     lines = [
         line
@@ -68,9 +60,7 @@ def test_stats_month_output_has_4_bars(
             return datetime(2023, 5, 31)
 
     monkeypatch.setattr(cli, "datetime", FakeDT)
-    result = runner.invoke(
-        cli.goal, ["stats", "--month"], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)}
-    )
+    result = runner.invoke(cli.goal, ["stats", "--month"])
     weeks = ["W1", "W2", "W3", "W4"]
     lines = [
         line
@@ -95,9 +85,7 @@ def test_stats_goals_table_shows_top5(
             return datetime(2023, 6, 2)
 
     monkeypatch.setattr(cli, "datetime", FakeDT)
-    result = runner.invoke(
-        cli.goal, ["stats", "--goals"], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)}
-    )
+    result = runner.invoke(cli.goal, ["stats", "--goals"])
     assert result.exit_code == 0
     assert "Top Goals" in result.output
     rows = [line for line in result.output.splitlines() if "│" in line]
@@ -113,9 +101,7 @@ def test_stats_empty_db_graceful(
             return datetime(2023, 6, 1)
 
     monkeypatch.setattr(cli, "datetime", FakeDT)
-    result = runner.invoke(
-        cli.goal, ["stats"], env={"GOAL_GLIDE_DB_DIR": str(tmp_path)}
-    )
+    result = runner.invoke(cli.goal, ["stats"])
     assert result.exit_code == 0
     assert "No session data" in result.output
 
@@ -137,7 +123,6 @@ def test_stats_custom_range(
     result = runner.invoke(
         cli.goal,
         ["stats", "--from", "2023-01-01", "--to", "2023-01-03"],
-        env={"GOAL_GLIDE_DB_DIR": str(tmp_path)},
     )
     lines = [line for line in result.output.splitlines() if line[:5].count("-") == 1]
     assert len(lines) == 3

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -2,13 +2,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
 from click.testing import CliRunner
 
 from goal_glide.cli import goal
 from goal_glide.models.storage import Storage
-
-
 
 
 def test_add_single_tag(tmp_path: Path, runner: CliRunner) -> None:

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -9,10 +9,6 @@ from goal_glide.cli import goal
 from goal_glide.models.storage import Storage
 
 
-@pytest.fixture()
-def runner(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> CliRunner:
-    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
-    return CliRunner()
 
 
 def test_add_single_tag(tmp_path: Path, runner: CliRunner) -> None:

--- a/tests/test_thoughts.py
+++ b/tests/test_thoughts.py
@@ -3,14 +3,11 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from pathlib import Path
 
-import pytest
 from click.testing import CliRunner
 
 from goal_glide.cli import goal, thought
 from goal_glide.models.storage import Storage
 from goal_glide.models.thought import Thought
-
-
 
 
 def test_jot_basic(tmp_path: Path, runner: CliRunner) -> None:

--- a/tests/test_thoughts.py
+++ b/tests/test_thoughts.py
@@ -11,10 +11,6 @@ from goal_glide.models.storage import Storage
 from goal_glide.models.thought import Thought
 
 
-@pytest.fixture()
-def runner(monkeypatch, tmp_path: Path) -> CliRunner:
-    monkeypatch.setenv("GOAL_GLIDE_DB_DIR", str(tmp_path))
-    return CliRunner()
 
 
 def test_jot_basic(tmp_path: Path, runner: CliRunner) -> None:


### PR DESCRIPTION
## Summary
- add global `runner` fixture configuring environment variables
- refactor CLI-related tests to use the new fixture
- install missing packages during test run to satisfy imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684680981f488322ab88fe4ca6ef30ec