### PR TITLE
Add Ruff pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,11 @@ repos:
   rev: 6.1.0
   hooks:
     - id: flake8
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.11.13
+  hooks:
+    - id: ruff
+      language_version: python3.11
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.8.0
   hooks:

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ pip install pre-commit
 pre-commit install
 ```
 
-The configured hook runs `black`, `flake8` and `mypy` on staged files so
+The configured hook runs `black`, `flake8`, `ruff` and `mypy` on staged files so
 issues are caught early.
 
 ## Documentation
@@ -342,4 +342,4 @@ pip install pre-commit
 pre-commit install
 ```
 
-The hooks defined in `.pre-commit-config.yaml` enforce coding standards using Black, Flake8 and Mypy.
+The hooks defined in `.pre-commit-config.yaml` enforce coding standards using Black, Flake8, Ruff and Mypy.


### PR DESCRIPTION
## Summary
- add Ruff linting hook to `.pre-commit-config.yaml`
- run Ruff with the same Python version as other hooks
- mention Ruff in the README instructions for `pre-commit`

## Testing
- `pre-commit run --files .pre-commit-config.yaml README.md`
- `pytest -q` *(fails: 27 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6846852925048322a2ce344d9b2c6f1b