### PR TITLE
Add deadline color rendering test

### DIFF
--- a/tests/test_render_service.py
+++ b/tests/test_render_service.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from goal_glide.models.goal import Goal, Priority
 from goal_glide.services.render import render_goals
@@ -26,3 +26,20 @@ def test_render_goals_row_count() -> None:
     assert table.columns[0].header == "ID"
     headers = [col.header for col in table.columns]
     assert "Deadline" in headers and "Completed" in headers
+
+
+def test_render_goals_deadline_coloring() -> None:
+    now = datetime.utcnow()
+    past = now - timedelta(days=1)
+    near = now + timedelta(days=2)
+    future = now + timedelta(days=5)
+    goals = [
+        Goal(id="1", title="past", created=now, deadline=past),
+        Goal(id="2", title="near", created=now, deadline=near),
+        Goal(id="3", title="future", created=now, deadline=future),
+    ]
+    table = render_goals(goals)
+    deadlines = table.columns[4]._cells
+    assert deadlines[0] == f"[red]{past.date().isoformat()}[/]"
+    assert deadlines[1] == f"[yellow]{near.date().isoformat()}[/]"
+    assert deadlines[2] == future.date().isoformat()


### PR DESCRIPTION
## Summary
- ensure `render_goals` colors deadlines correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684770f644c88322b02d491b5c68b031