### PR TITLE
Add deadline color test for TUI

### DIFF
--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -125,3 +125,34 @@ def test_update_detail_with_goal(app_env, tmp_path):
             assert "Press S to start Pomodoro" in str(panel.renderable)
 
     asyncio.run(run())
+
+
+def test_update_detail_deadline_color(app_env, tmp_path):
+    if not _setup_textual():
+        pytest.skip("textual not available")
+    from datetime import timedelta
+    from textual.widgets import Static
+    from goal_glide.tui import GoalGlideApp
+
+    storage = Storage(tmp_path / "db.json")
+    now = datetime.utcnow()
+    past = Goal(id="g1", title="Past", created=now, deadline=now - timedelta(days=1))
+    soon = Goal(id="g2", title="Soon", created=now, deadline=now + timedelta(days=2))
+    storage.add_goal(past)
+    storage.add_goal(soon)
+
+    async def run() -> None:
+        async with GoalGlideApp().run_test() as pilot:
+            await pilot.pause()
+
+            pilot.app.selected_goal = past.id
+            pilot.app.update_detail()
+            panel = pilot.app.query_one("#detail_panel", Static)
+            assert f"Deadline: [red]{past.deadline:%Y-%m-%d}" in str(panel.renderable)
+
+            pilot.app.selected_goal = soon.id
+            pilot.app.update_detail()
+            panel = pilot.app.query_one("#detail_panel", Static)
+            assert f"Deadline: [yellow]{soon.deadline:%Y-%m-%d}" in str(panel.renderable)
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- add async test to verify update_detail colors deadlines red or yellow

## Testing
- `pytest tests/test_tui.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684784eb0d3c8322b8fd9cc7200ec1b5